### PR TITLE
6.1 Release Prep

### DIFF
--- a/Documentation/Connect-LMAccount.md
+++ b/Documentation/Connect-LMAccount.md
@@ -260,5 +260,7 @@ You must run this command before you will be able to execute other commands incl
 
 ## RELATED LINKS
 
+[Module repo: https://github.com/logicmonitor/lm-powershell-module]()
+
 [PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor]()
 

--- a/Documentation/Disconnect-LMAccount.md
+++ b/Documentation/Disconnect-LMAccount.md
@@ -13,7 +13,7 @@ Disconnect from a previously connected LM portal
 ## SYNTAX
 
 ```
-Disconnect-LMAccount [<CommonParameters>]
+Disconnect-LMAccount
 ```
 
 ## DESCRIPTION
@@ -29,9 +29,6 @@ Disconnect-LMAccount
 
 ## PARAMETERS
 
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
 ## INPUTS
 
 ### None. You cannot pipe objects to this command.
@@ -41,6 +38,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 Once disconnect you will need to reconnect to a portal before you will be allowed to run commands again.
 
 ## RELATED LINKS
+
+[Module repo: https://github.com/logicmonitor/lm-powershell-module]()
 
 [PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor]()
 

--- a/Documentation/Export-LMDeviceConfigBackup.md
+++ b/Documentation/Export-LMDeviceConfigBackup.md
@@ -143,5 +143,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[Module repo: https://github.com/logicmonitor/lm-powershell-module]()
+
 [PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor]()
 

--- a/Documentation/Export-LMLogicModule.md
+++ b/Documentation/Export-LMLogicModule.md
@@ -129,5 +129,7 @@ You must run this command before you will be able to execute other commands incl
 
 ## RELATED LINKS
 
+[Module repo: https://github.com/logicmonitor/lm-powershell-module]()
+
 [PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor]()
 

--- a/Documentation/Get-LMAWSAccountId.md
+++ b/Documentation/Get-LMAWSAccountId.md
@@ -1,0 +1,59 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version: https://www.logicmonitor.com/support/rest-api-developers-guide/
+schema: 2.0.0
+---
+
+# Get-LMAWSAccountId
+
+## SYNOPSIS
+Retrieves the AWS Account ID associated with the LogicMonitor account.
+
+## SYNTAX
+
+```
+Get-LMAWSAccountId [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-LMAWSAccountId function is used to retrieve the AWS Account ID associated with the LogicMonitor account.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, and then sends a GET request to the LogicMonitor API to retrieve the AWS Account ID.
+The function returns the response containing the AWS Account ID.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-LMAWSAccountId
+Retrieves the AWS Account ID associated with the LogicMonitor account.
+```
+
+## PARAMETERS
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Documentation/Get-LMAccountStatus.md
+++ b/Documentation/Get-LMAccountStatus.md
@@ -13,7 +13,7 @@ Retrieves the status of the LogicMonitor account.
 ## SYNTAX
 
 ```
-Get-LMAccountStatus [<CommonParameters>]
+Get-LMAccountStatus
 ```
 
 ## DESCRIPTION
@@ -30,9 +30,6 @@ Get-LMAccountStatus
 This example demonstrates how to use the Get-LMAccountStatus function to retrieve the status of the LogicMonitor account.
 
 ## PARAMETERS
-
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/Documentation/Get-LMConfigsourceUpdateHistory.md
+++ b/Documentation/Get-LMConfigsourceUpdateHistory.md
@@ -5,59 +5,59 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# Get-LMConfigsourceUpdateHistory
 
 ## SYNOPSIS
-Retrieves the update history of a LogicMonitor datasource.
+Retrieves the update history for a LogicMonitor configuration source.
 
 ## SYNTAX
 
 ### Id (Default)
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMConfigsourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Name
 ```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMConfigsourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### DisplayName
 ```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMConfigsourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-LMDatasourceUpdateHistory function retrieves the update history of a LogicMonitor datasource.
-It can be used to get information about the updates made to a datasource, such as the reasons for the updates.
+The Get-LMConfigsourceUpdateHistory function retrieves the update history for a LogicMonitor configuration source.
+It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Get-LMDatasourceUpdateHistory -Id 1234
-Retrieves the update history of the datasource with ID 1234.
+Get-LMConfigsourceUpdateHistory -Id 1234
+Retrieves the update history for the configuration source with the ID 1234.
 ```
 
 ### EXAMPLE 2
 ```
-Get-LMDatasourceUpdateHistory -Name "MyDatasource"
-Retrieves the update history of the datasource with the name "MyDatasource".
+Get-LMConfigsourceUpdateHistory -Name "MyConfigSource"
+Retrieves the update history for the configuration source with the name "MyConfigSource".
 ```
 
 ### EXAMPLE 3
 ```
-Get-LMDatasourceUpdateHistory -DisplayName "My Datasource"
-Retrieves the update history of the datasource with the display name "My Datasource".
+Get-LMConfigsourceUpdateHistory -DisplayName "My Config Source"
+Retrieves the update history for the configuration source with the display name "My Config Source".
 ```
 
 ## PARAMETERS
 
 ### -Id
-The ID of the datasource.
+The ID of the configuration source.
 This parameter is mandatory when using the 'Id' parameter set.
 
 ```yaml
@@ -73,10 +73,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-The name of the datasource.
-This parameter is used to look up the ID of the datasource.
-If the name is provided, the function will automatically retrieve the ID of the datasource.
-This parameter is used in the 'Name' parameter set.
+The name of the configuration source.
+This parameter is used to look up the ID of the configuration source.
+This parameter is used when using the 'Name' parameter set.
 
 ```yaml
 Type: String
@@ -91,10 +90,9 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
-The display name of the datasource.
-This parameter is used to look up the ID of the datasource.
-If the display name is provided, the function will automatically retrieve the ID of the datasource.
-This parameter is used in the 'DisplayName' parameter set.
+The display name of the configuration source.
+This parameter is used to look up the ID of the configuration source.
+This parameter is used when using the 'DisplayName' parameter set.
 
 ```yaml
 Type: String
@@ -109,9 +107,8 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-A filter object that can be used to filter the results.
-The filter object should contain properties that match the properties of the datasource.
-Only datasources that match the filter will be included in the results.
+A filter object that specifies additional filtering criteria for the update history.
+This parameter is optional.
 
 ```yaml
 Type: Object
@@ -126,8 +123,9 @@ Accept wildcard characters: False
 ```
 
 ### -BatchSize
-The number of results to retrieve in each batch.
+The number of results to retrieve per request.
 The default value is 1000.
+This parameter is optional.
 
 ```yaml
 Type: Int32

--- a/Documentation/Invoke-LMAWSAccountTest.md
+++ b/Documentation/Invoke-LMAWSAccountTest.md
@@ -1,0 +1,140 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMAWSAccountTest
+
+## SYNOPSIS
+Invokes a test for an AWS account in LogicMonitor.
+
+## SYNTAX
+
+```
+Invoke-LMAWSAccountTest [-ExternalId] <String> [[-AccountId] <String>] [-AssumedRoleARN] <String>
+ [[-CheckedServices] <String>] [[-GroupId] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMAWSAccountTest function is used to invoke a test for an AWS account in LogicMonitor.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test.
+The function returns the response from the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123
+```
+
+This example invokes a test for an AWS account with the specified parameters.
+
+## PARAMETERS
+
+### -ExternalId
+The external ID of the AWS account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AccountId
+The account ID of the AWS account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AssumedRoleARN
+The assumed role ARN of the AWS account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckedServices
+The list of services to be checked during the test.
+Default value is a comma-separated string of service names supported by LogicMonitor.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+The device group ID to which the AWS account belongs.
+Default value is -1 for no group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: -1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+This function requires the user to be logged in before running any commands.
+Use the Connect-LMAccount function to log in before invoking this function.
+
+## RELATED LINKS

--- a/Documentation/Invoke-LMAzureAccountTest.md
+++ b/Documentation/Invoke-LMAzureAccountTest.md
@@ -1,0 +1,170 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMAzureAccountTest
+
+## SYNOPSIS
+Invokes a test on an Azure account.
+
+## SYNTAX
+
+```
+Invoke-LMAzureAccountTest [-ClientId] <String> [-SecretKey] <String> [[-CheckedServices] <String>]
+ [-SubscriptionIds] <String> [[-GroupId] <String>] [-TenantId] <String> [[-IsChinaAccount] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMAzureAccountTest function is used to invoke a test on an Azure account.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, and then sends a POST request to the specified endpoint.
+The function returns the response from the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMAzureAccountTest -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SubscriptionIds "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+This example invokes a test on an Azure account using the specified client ID, secret key, and subscription IDs.
+
+## PARAMETERS
+
+### -ClientId
+The client ID of the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecretKey
+The secret key of the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckedServices
+The list of services to be checked.
+Default value is a list of commonly used Azure services.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SubscriptionIds
+The subscription IDs associated with the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+The group ID.
+Default value is -1.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: -1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TenantId
+The tenant ID of the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsChinaAccount
+Specifies whether the Azure account is a China account.
+Default value is $false.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Documentation/Invoke-LMAzureSubscriptionDiscovery.md
+++ b/Documentation/Invoke-LMAzureSubscriptionDiscovery.md
@@ -1,0 +1,117 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMAzureSubscriptionDiscovery
+
+## SYNOPSIS
+Invokes the Azure subscription discovery process to return subscriptions for a specified client Id.
+
+## SYNTAX
+
+```
+Invoke-LMAzureSubscriptionDiscovery [-ClientId] <String> [-SecretKey] <String> [-TenantId] <String>
+ [[-IsChinaAccount] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMAzureSubscriptionDiscovery function is used to discover Azure subscriptions by making API requests to the LogicMonitor platform.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+## PARAMETERS
+
+### -ClientId
+The client ID of the Azure Active Directory application.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecretKey
+The secret key of the Azure Active Directory application.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TenantId
+The tenant ID of the Azure Active Directory application.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsChinaAccount
+Specifies whether the Azure account is a China account.
+Default value is $false.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Documentation/Invoke-LMGCPAccountTest.md
+++ b/Documentation/Invoke-LMGCPAccountTest.md
@@ -1,0 +1,125 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMGCPAccountTest
+
+## SYNOPSIS
+Invokes a test for a GCP (Google Cloud Platform) account.
+
+## SYNTAX
+
+```
+Invoke-LMGCPAccountTest [-ServiceAccountKey] <String> [-ProjectId] <String> [[-CheckedServices] <String>]
+ [[-GroupId] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMGCPAccountTest function is used to invoke a test for a GCP account.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test.
+The function returns the response from the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"
+```
+
+This example invokes a test for a GCP account using the specified service account key and project ID.
+
+## PARAMETERS
+
+### -ServiceAccountKey
+The service account key for the GCP account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+The ID of the GCP project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckedServices
+(Optional) A comma-separated list of GCP services to be checked.
+The default value is a list of all LM supported GCP services.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+(Optional) The ID of the group to which the GCP account belongs.
+The default value is -1, indicating no group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: -1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+This function requires the user to be logged in before running any commands.
+Use the Connect-LMAccount function to log in before invoking this function.
+
+## RELATED LINKS

--- a/Documentation/Set-LMDevice.md
+++ b/Documentation/Set-LMDevice.md
@@ -15,21 +15,21 @@ schema: 2.0.0
 ### Id
 ```
 Set-LMDevice -Id <String> [-NewName <String>] [-DisplayName <String>] [-Description <String>]
- [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-Properties <Hashtable>]
- [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>] [-DisableAlerting <Boolean>]
- [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>] [-NetflowCollectorId <Int32>]
- [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-AutoBalancedCollectorGroupId <Int32>]
+ [-Properties <Hashtable>] [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>]
+ [-DisableAlerting <Boolean>] [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>]
+ [-NetflowCollectorId <Int32>] [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Name
 ```
 Set-LMDevice -Name <String> [-NewName <String>] [-DisplayName <String>] [-Description <String>]
- [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-Properties <Hashtable>]
- [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>] [-DisableAlerting <Boolean>]
- [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>] [-NetflowCollectorId <Int32>]
- [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-AutoBalancedCollectorGroupId <Int32>]
+ [-Properties <Hashtable>] [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>]
+ [-DisableAlerting <Boolean>] [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>]
+ [-NetflowCollectorId <Int32>] [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,6 +45,21 @@ PS C:\> {{ Add example code here }}
 {{ Add example description here }}
 
 ## PARAMETERS
+
+### -AutoBalancedCollectorGroupId
+{{ Fill AutoBalancedCollectorGroupId Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.

--- a/Documentation/Set-LMUserdata.md
+++ b/Documentation/Set-LMUserdata.md
@@ -1,0 +1,156 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Set-LMUserdata
+
+## SYNOPSIS
+Sets userdata for a LogicMonitor user.
+Currently only setting the default dashboard is supported.
+
+## SYNTAX
+
+### Id (Default)
+```
+Set-LMUserdata -Id <String> -DashboardId <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Name
+```
+Set-LMUserdata -Name <String> -DashboardId <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-LMUserdata function is used to set the user data for a LogicMonitor user.
+It allows you to specify the user by either their Id or Name, and the dashboard Id for which the user data should be set.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-LMUserdata -Id "12345" -DashboardId "67890"
+Sets the user data for the user with Id "12345" for the dashboard with Id "67890".
+```
+
+### EXAMPLE 2
+```
+Set-LMUserdata -Name "JohnDoe" -DashboardId "67890"
+Sets the user data for the user with Name "JohnDoe" for the dashboard with Id "67890".
+```
+
+## PARAMETERS
+
+### -Id
+Specifies the Id of the user.
+This parameter is mandatory when using the 'Id' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Id
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the Name of the user.
+This parameter is mandatory when using the 'Name' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Name
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DashboardId
+Specifies the Id of the dashboard for which the user data should be set.
+This parameter is mandatory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None.
+## OUTPUTS
+
+### System.Object
+### Returns the response from the LogicMonitor API.
+## NOTES
+This function requires a valid API authentication.
+Make sure you are logged in before running any commands using Connect-LMAccount.
+
+## RELATED LINKS

--- a/Logic.Monitor.Format.ps1xml
+++ b/Logic.Monitor.Format.ps1xml
@@ -54,6 +54,59 @@
             </TableRowEntries>
          </TableControl>
       </View>
+      <!-- New View LogicMonitor.ModuleUpdateHistory-->
+      <View>
+         <Name>LogicMonitorModuleUpdateHistory</Name>
+         <ViewSelectedBy>
+            <TypeName>LogicMonitor.ModuleUpdateHistory</TypeName>
+         </ViewSelectedBy>
+         <TableControl>
+            <TableHeaders>
+               <TableColumnHeader>
+                  <Label>id</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>username</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>timeStr</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>timeEpoch</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>clientIp</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>updateReason</Label>
+               </TableColumnHeader>
+            </TableHeaders>
+            <TableRowEntries>
+               <TableRowEntry>
+                  <TableColumnItems>
+                     <TableColumnItem>
+                        <PropertyName>id</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>username</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>timeStr</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>timeEpoch</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>clientIp</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>updateReason</PropertyName>
+                     </TableColumnItem>
+                  </TableColumnItems>
+               </TableRowEntry>
+            </TableRowEntries>
+         </TableControl>
+      </View>
       <!-- New View LogicMonitor.TopologyMap-->
       <View>
          <Name>LogicMonitorTopologyMap</Name>

--- a/Public/Get-LMAWSAccountId.ps1
+++ b/Public/Get-LMAWSAccountId.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+Retrieves the AWS Account ID associated with the LogicMonitor account.
+
+.DESCRIPTION
+The Get-LMAWSAccountId function is used to retrieve the AWS Account ID associated with the LogicMonitor account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, and then sends a GET request to the LogicMonitor API to retrieve the AWS Account ID. The function returns the response containing the AWS Account ID.
+
+.PARAMETER None
+This function does not have any parameters.
+
+.EXAMPLE
+Get-LMAWSAccountId
+Retrieves the AWS Account ID associated with the LogicMonitor account.
+#>
+
+Function Get-LMAWSAccountId {
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    Param ()
+
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+        
+        #Build header and uri
+        $ResourcePath = "/aws/accountId"
+
+        Try {
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath + $QueryParams
+                
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
+            Return $Response
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Get-LMConfigsourceUpdateHistory.ps1
+++ b/Public/Get-LMConfigsourceUpdateHistory.ps1
@@ -1,39 +1,39 @@
 <#
 .SYNOPSIS
-Retrieves the update history of a LogicMonitor datasource.
+Retrieves the update history for a LogicMonitor configuration source.
 
 .DESCRIPTION
-The Get-LMDatasourceUpdateHistory function retrieves the update history of a LogicMonitor datasource. It can be used to get information about the updates made to a datasource, such as the reasons for the updates.
+The Get-LMConfigsourceUpdateHistory function retrieves the update history for a LogicMonitor configuration source. It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated.
 
 .PARAMETER Id
-The ID of the datasource. This parameter is mandatory when using the 'Id' parameter set.
+The ID of the configuration source. This parameter is mandatory when using the 'Id' parameter set.
 
 .PARAMETER Name
-The name of the datasource. This parameter is used to look up the ID of the datasource. If the name is provided, the function will automatically retrieve the ID of the datasource. This parameter is used in the 'Name' parameter set.
+The name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'Name' parameter set.
 
 .PARAMETER DisplayName
-The display name of the datasource. This parameter is used to look up the ID of the datasource. If the display name is provided, the function will automatically retrieve the ID of the datasource. This parameter is used in the 'DisplayName' parameter set.
+The display name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'DisplayName' parameter set.
 
 .PARAMETER Filter
-A filter object that can be used to filter the results. The filter object should contain properties that match the properties of the datasource. Only datasources that match the filter will be included in the results.
+A filter object that specifies additional filtering criteria for the update history. This parameter is optional.
 
 .PARAMETER BatchSize
-The number of results to retrieve in each batch. The default value is 1000.
+The number of results to retrieve per request. The default value is 1000. This parameter is optional.
 
 .EXAMPLE
-Get-LMDatasourceUpdateHistory -Id 1234
-Retrieves the update history of the datasource with ID 1234.
+Get-LMConfigsourceUpdateHistory -Id 1234
+Retrieves the update history for the configuration source with the ID 1234.
 
 .EXAMPLE
-Get-LMDatasourceUpdateHistory -Name "MyDatasource"
-Retrieves the update history of the datasource with the name "MyDatasource".
+Get-LMConfigsourceUpdateHistory -Name "MyConfigSource"
+Retrieves the update history for the configuration source with the name "MyConfigSource".
 
 .EXAMPLE
-Get-LMDatasourceUpdateHistory -DisplayName "My Datasource"
-Retrieves the update history of the datasource with the display name "My Datasource".
+Get-LMConfigsourceUpdateHistory -DisplayName "My Config Source"
+Retrieves the update history for the configuration source with the display name "My Config Source".
 
 #>
-Function Get-LMDatasourceUpdateHistory {
+Function Get-LMConfigsourceUpdateHistory {
 
     [CmdletBinding(DefaultParameterSetName = 'Id')]
     Param (
@@ -48,14 +48,14 @@ Function Get-LMDatasourceUpdateHistory {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
         If ($Name) {
-            $LookupResult = (Get-LMDatasource -Name $Name).Id
+            $LookupResult = (Get-LMConfigsource -Name $Name).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
                 return
             }
@@ -63,7 +63,7 @@ Function Get-LMDatasourceUpdateHistory {
         }
 
         If ($DisplayName) {
-            $LookupResult = (Get-LMDatasource -DisplayName $DisplayName).Id
+            $LookupResult = (Get-LMConfigsource -DisplayName $DisplayName).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DisplayName) {
                 return
             }
@@ -71,7 +71,7 @@ Function Get-LMDatasourceUpdateHistory {
         }
         
         #Build header and uri
-        $ResourcePath = "/setting/datasources/$Id/updatereasons"
+        $ResourcePath = "/setting/configsources/$Id/updatereasons"
 
         #Initalize vars
         $QueryParams = ""

--- a/Public/Invoke-LMAWSAccountTest.ps1
+++ b/Public/Invoke-LMAWSAccountTest.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+Invokes a test for an AWS account in LogicMonitor.
+
+.DESCRIPTION
+The Invoke-LMAWSAccountTest function is used to invoke a test for an AWS account in LogicMonitor. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test. The function returns the response from the API.
+
+.PARAMETER ExternalId
+The external ID of the AWS account.
+
+.PARAMETER AccountId
+The account ID of the AWS account.
+
+.PARAMETER AccessId
+The access ID of the AWS account.
+
+.PARAMETER AccessKey
+The access key of the AWS account.
+
+.PARAMETER AssumedRoleARN
+The assumed role ARN of the AWS account.
+
+.PARAMETER CheckedServices
+The list of services to be checked during the test. Default value is a comma-separated string of service names supported by LogicMonitor.
+
+.PARAMETER GroupId
+The device group ID to which the AWS account belongs. Default value is -1 for no group.
+
+.EXAMPLE
+Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123
+
+This example invokes a test for an AWS account with the specified parameters.
+
+.NOTES
+This function requires the user to be logged in before running any commands. Use the Connect-LMAccount function to log in before invoking this function.
+#>
+Function Invoke-LMAWSAccountTest {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$ExternalId,
+
+        [Parameter()]
+        [String]$AccountId,
+
+        [Parameter(Mandatory)]
+        [String]$AssumedRoleARN,
+
+        [String]$CheckedServices = "DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS",
+
+        [String]$GroupId = -1
+
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+        
+        #Build header and uri
+        $ResourcePath = "/aws/functions/testAccount"
+
+        Try {
+            $Data = @{
+                externalId      = $ExternalId
+                accountId       = $AccountId
+                assumedRoleArn  = $AssumedRoleARN
+                checkedServices = $CheckedServices
+                groupId         = $GroupId
+            }
+
+            #Remove empty keys so we dont overwrite them
+            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+
+            $Data = ($Data | ConvertTo-Json)
+
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+            Write-LMHost "All services have been tested successfully" -ForegroundColor Green
+            Return
+        }
+        Catch [Exception] {
+            #Handle LMCloud test account permission errors
+            If ($PSItem.Exception.Response.StatusCode.value__ -eq 400 -and $PSItem.Exception.Response.RequestMessage.RequestUri.AbsolutePath -like "*/testAccount") {
+                $Result = @()
+                ($PSItem.ErrorDetails.Message | ConvertFrom-Json).errorDetail.noPermissionServices | ForEach-Object {
+                    $Result += [PSCustomObject]@{
+                        Service = $PSItem
+                        TestResult = "You do not have permission to access the service"
+                    }
+                }
+                return $Result
+            }
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Invoke-LMAzureAccountTest.ps1
+++ b/Public/Invoke-LMAzureAccountTest.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Invokes a test on an Azure account.
+
+.DESCRIPTION
+    The Invoke-LMAzureAccountTest function is used to invoke a test on an Azure account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, and then sends a POST request to the specified endpoint. The function returns the response from the API.
+
+.PARAMETER ClientId
+    The client ID of the Azure account.
+
+.PARAMETER SecretKey
+    The secret key of the Azure account.
+
+.PARAMETER CheckedServices
+    The list of services to be checked. Default value is a list of commonly used Azure services.
+
+.PARAMETER SubscriptionIds
+    The subscription IDs associated with the Azure account.
+
+.PARAMETER GroupId
+    The group ID. Default value is -1.
+
+.PARAMETER TenantId
+    The tenant ID of the Azure account.
+
+.PARAMETER IsChinaAccount
+    Specifies whether the Azure account is a China account. Default value is $false.
+
+.EXAMPLE
+    Invoke-LMAzureAccountTest -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SubscriptionIds "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+    This example invokes a test on an Azure account using the specified client ID, secret key, and subscription IDs.
+#>
+Function Invoke-LMAzureAccountTest {
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$ClientId,
+
+        [Parameter(Mandatory)]
+        [String]$SecretKey,
+
+        [String]$CheckedServices = "VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS",
+
+        [Parameter(Mandatory)]
+        [String]$SubscriptionIds,
+
+        [String]$GroupId = -1,
+
+        [Parameter(Mandatory)]
+        [String]$TenantId,
+
+        [String]$IsChinaAccount = $false
+
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+        
+        #Build header and uri
+        $ResourcePath = "/azure/functions/testAccount"
+
+        Try {
+            $Data = @{
+                clientId        = $ClientId
+                secretKey       = $SecretKey
+                checkedServices = $CheckedServices
+                subscriptionIds = $SubscriptionIds
+                groupId         = $GroupId
+                tenantId        = $TenantId
+                isChinaAccount  = $IsChinaAccount
+
+            }
+
+            #Remove empty keys so we dont overwrite them
+            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+
+            $Data = ($Data | ConvertTo-Json)
+
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+            Write-LMHost "All services have been tested successfully" -ForegroundColor Green
+            Return
+        }
+        Catch [Exception] {
+            #Handle LMCloud test account permission errors
+            If ($PSItem.Exception.Response.StatusCode.value__ -eq 400 -and $PSItem.Exception.Response.RequestMessage.RequestUri.AbsolutePath -like "*/testAccount") {
+                $Result = @()
+                ($PSItem.ErrorDetails.Message | ConvertFrom-Json).errorDetail.noPermissionServices.services.serviceName | ForEach-Object {
+                    $Result += [PSCustomObject]@{
+                        Service = $PSItem
+                        TestResult = "You do not have permission to access the service"
+                    }
+                }
+                return $Result
+            }
+            Else{
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Invoke-LMAzureSubscriptionDiscovery.ps1
+++ b/Public/Invoke-LMAzureSubscriptionDiscovery.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+    Invokes the Azure subscription discovery process to return subscriptions for a specified client Id.
+
+.DESCRIPTION
+    The Invoke-LMAzureSubscriptionDiscovery function is used to discover Azure subscriptions by making API requests to the LogicMonitor platform.
+
+.PARAMETER ClientId
+    The client ID of the Azure Active Directory application.
+
+.PARAMETER SecretKey
+    The secret key of the Azure Active Directory application.
+
+.PARAMETER TenantId
+    The tenant ID of the Azure Active Directory application.
+
+.PARAMETER IsChinaAccount
+    Specifies whether the Azure account is a China account. Default value is $false.
+
+.EXAMPLE
+    Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#>
+Function Invoke-LMAzureSubscriptionDiscovery {
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$ClientId,
+
+        [Parameter(Mandatory)]
+        [String]$SecretKey,
+
+        [Parameter(Mandatory)]
+        [String]$TenantId,
+
+        [String]$IsChinaAccount = $false
+
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+        
+        #Build header and uri
+        $ResourcePath = "/azure/functions/discoverSubscriptions"
+
+        #Loop through requests 
+        $Done = $false
+        While (!$Done) {
+            Try {
+                $Data = @{
+                    clientId        = $ClientId
+                    secretKey       = $SecretKey
+                    tenantId        = $TenantId
+                    isChinaAccount  = $IsChinaAccount
+
+                }
+
+                #Remove empty keys so we dont overwrite them
+                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+
+                $Data = ($Data | ConvertTo-Json)
+
+                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+                $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                #Issue request
+                $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                Return $Response.items
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Invoke-LMGCPAccountTest.ps1
+++ b/Public/Invoke-LMGCPAccountTest.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+Invokes a test for a GCP (Google Cloud Platform) account.
+
+.DESCRIPTION
+The Invoke-LMGCPAccountTest function is used to invoke a test for a GCP account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test. The function returns the response from the API.
+
+.PARAMETER ServiceAccountKey
+The service account key for the GCP account.
+
+.PARAMETER ProjectId
+The ID of the GCP project.
+
+.PARAMETER CheckedServices
+(Optional) A comma-separated list of GCP services to be checked. The default value is a list of all LM supported GCP services.
+
+.PARAMETER GroupId
+(Optional) The ID of the group to which the GCP account belongs. The default value is -1, indicating no group.
+
+.EXAMPLE
+Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"
+
+This example invokes a test for a GCP account using the specified service account key and project ID.
+
+.NOTES
+This function requires the user to be logged in before running any commands. Use the Connect-LMAccount function to log in before invoking this function.
+#>
+Function Invoke-LMGCPAccountTest {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$ServiceAccountKey,
+
+        [Parameter(Mandatory)]
+        [String]$ProjectId,
+
+        [String]$CheckedServices = "CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER",
+
+        [String]$GroupId = -1
+
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+        
+        #Build header and uri
+        $ResourcePath = "/gcp/functions/testAccount"
+
+        Try {
+            $Data = @{
+                serviceAccountKey   = $ServiceAccountKey
+                projectId           = $ProjectId
+                checkedServices     = $CheckedServices
+                groupId             = $GroupId
+            }
+
+            #Remove empty keys so we dont overwrite them
+            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+
+            $Data = ($Data | ConvertTo-Json)
+
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+            Write-LMHost "All services have been tested successfully" -ForegroundColor Green
+            Return
+        }
+        Catch [Exception] {
+            #Handle LMCloud test account permission errors
+            If ($PSItem.Exception.Response.StatusCode.value__ -eq 400 -and $PSItem.Exception.Response.RequestMessage.RequestUri.AbsolutePath -like "*/testAccount") {
+                $Result = @()
+                ($PSItem.ErrorDetails.Message | ConvertFrom-Json).errorDetail.noPermissionServices | ForEach-Object {
+                    $Result += [PSCustomObject]@{
+                        Service = $PSItem
+                        TestResult = "You do not have permission to access the service"
+                    }
+                }
+                return $Result
+            }
+            Else{
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Set-LMDevice.ps1
+++ b/Public/Set-LMDevice.ps1
@@ -18,6 +18,8 @@ Function Set-LMDevice {
 
         [Nullable[Int]]$PreferredCollectorGroupId,
 
+        [Nullable[Int]]$AutoBalancedCollectorGroupId,
+
         [Hashtable]$Properties,
 
         [String[]]$HostGroupIds, #Dynamic group ids will be ignored, operation will replace all existing groups
@@ -76,20 +78,21 @@ Function Set-LMDevice {
 
             Try {
                 $Data = @{
-                    name                      = $NewName
-                    displayName               = $DisplayName
-                    description               = $Description
-                    disableAlerting           = $DisableAlerting
-                    enableNetflow             = $EnableNetFlow
-                    customProperties          = $customProperties
-                    preferredCollectorId      = $PreferredCollectorId
-                    preferredCollectorGroupId = $PreferredCollectorGroupId
-                    link                      = $Link
-                    netflowCollectorGroupId   = $NetflowCollectorGroupId
-                    netflowCollectorId        = $NetflowCollectorId
-                    logCollectorGroupId       = $LogCollectorGroupId
-                    logCollectorId            = $LogCollectorId
-                    hostGroupIds              = $HostGroupIds -join ","
+                    name                         = $NewName
+                    displayName                  = $DisplayName
+                    description                  = $Description
+                    disableAlerting              = $DisableAlerting
+                    enableNetflow                = $EnableNetFlow
+                    customProperties             = $customProperties
+                    preferredCollectorId         = $PreferredCollectorId
+                    preferredCollectorGroupId    = $PreferredCollectorGroupId
+                    autoBalancedCollectorGroupId = $AutoBalancedCollectorGroupId
+                    link                         = $Link
+                    netflowCollectorGroupId      = $NetflowCollectorGroupId
+                    netflowCollectorId           = $NetflowCollectorId
+                    logCollectorGroupId          = $LogCollectorGroupId
+                    logCollectorId               = $LogCollectorId
+                    hostGroupIds                 = $HostGroupIds -join ","
                 }
 
                 

--- a/Public/Set-LMUserdata.ps1
+++ b/Public/Set-LMUserdata.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+Sets userdata for a LogicMonitor user. Currently only setting the default dashboard is supported.
+
+.DESCRIPTION
+The Set-LMUserdata function is used to set the user data for a LogicMonitor user. It allows you to specify the user by either their Id or Name, and the dashboard Id for which the user data should be set.
+
+.PARAMETER Id
+Specifies the Id of the user. This parameter is mandatory when using the 'Id' parameter set.
+
+.PARAMETER Name
+Specifies the Name of the user. This parameter is mandatory when using the 'Name' parameter set.
+
+.PARAMETER DashboardId
+Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.
+
+.EXAMPLE
+Set-LMUserdata -Id "12345" -DashboardId "67890"
+Sets the user data for the user with Id "12345" for the dashboard with Id "67890".
+
+.EXAMPLE
+Set-LMUserdata -Name "JohnDoe" -DashboardId "67890"
+Sets the user data for the user with Name "JohnDoe" for the dashboard with Id "67890".
+
+.INPUTS
+None.
+
+.OUTPUTS
+System.Object
+Returns the response from the LogicMonitor API.
+
+.NOTES
+This function requires a valid API authentication. Make sure you are logged in before running any commands using Connect-LMAccount.
+
+#>
+Function Set-LMUserdata {
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'None')]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
+        [String]$Id,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String]$Name,
+
+        [Parameter(Mandatory)]
+        [String]$DashboardId
+    )
+
+    Begin {}
+    Process {
+        #Check if we are logged in and have valid api creds
+        If ($Script:LMAuth.Valid) {
+
+            #Lookup Id if supplying AdminName
+            If ($Name) {
+                $LookupResult = (Get-LMUser -Name $Name).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $Id = $LookupResult
+            }
+
+            #Get Dashboard JSON response
+            If ($DashboardId) {
+                $Dashboard = Get-LMDashboard -Id $DashboardId
+                If (Test-LookupResult -Result $Dashboard -LookupString $DashboardId) {
+                    return
+                }
+                $Value = $Dashboard | ConvertTo-Json
+            }
+            
+            #Build header and uri
+            $ResourcePath = "/setting/userdata/$Id.user.default.dashboard"
+
+            If ($PSItem) {
+                $Message = "Id: $Id | AccessId: $($PSItem.accessId)| AdminName:$($PSItem.adminName)"
+            }
+            Else {
+                $Message = "Id: $Id"
+            }
+
+            Try {
+                $Data = @{
+                    id    = "$Id.user.default.dashboard"
+                    value = $Value
+                }
+                
+                #Remove empty keys so we dont overwrite them
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                
+                If ($Status) {
+                    $Data.status = $(If ($Status -eq "active") { 2 }Else { 1 })
+                }
+                
+                $Data = ($Data | ConvertTo-Json)
+                
+                If ($PSCmdlet.ShouldProcess($Message, "Set API Token")) {  
+                    $Headers = New-LMHeader -Auth $Script:LMAuth -Method "PATCH" -ResourcePath $ResourcePath -Data $Data 
+                    $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+                    Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                    #Issue request
+                    $Response = Invoke-RestMethod -Uri $Uri -Method "PATCH" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                    $Result = [PSCustomObject]@{
+                        Id      = $Id
+                        Message = "Successfully updated userdata for default dashboard to id: ($DashboardId)"
+                    }
+
+                    Return $Result
+                }
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {}
+}

--- a/README.md
+++ b/README.md
@@ -409,18 +409,30 @@ This change aims to enhance visibility within the community and to foster a more
 
 We appreciate your continued support and enthusiasm for the Logic.Monitor PowerShell module. Your contributions and feedback are vital to the success of this project, and we look forward to seeing how the module evolves with your participation.
 
-## 6.0
+## 6.1
 ### New Cmdlets:
- - **Get-LMDeviceInstanceData**: This cmdlet retrieves data for LogicMonitor device instances based on the specified parameters. The cmdlet can only retrieve data within the last 24 hours. You can use `Get-LMDeviceInstanceList` to quickly get a list of instances for a particular device.
- - **New-LMAlertEscalation**: This cmdlet invokes an escalation for a LogicMonitor alert. It takes a *-Ids* parameter which is an array of alert ids to escalate.
- - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
- 
- **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.
-
+ - **Get-LMAWSAccountId**: This cmdlet is used to retrieve the AWS Account ID associated with the LogicMonitor account.
+ - **Get-LMConfigsourceUpdateHistory**: This cmdlet retrieves the update history for a LogicMonitor configuration source. It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated..
+ - **Invoke-LMAWSAccountTest**: This cmdlet will test for required permissions needed to add an AWS account to LogicMonitor. 
+    ```
+    Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123
+    ```
+- **Invoke-LMAzureAccountTest**: This cmdlet will test for required permissions needed to add an Azure account to LogicMonitor. 
+  ```
+  Invoke-LMAzureAccountTest -ClientId "xxxxxxxx" -SecretKey "xxxxxxxx" -SubscriptionIds "xxxxxxxx"
+  ```
+- **Invoke-LMAzureSubscriptionDiscovery**: This cmdlet invokes the Azure subscription discovery process to return subscriptions for a specified client Id. 
+  ```
+    Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx" -SecretKey "xxxxxxxx" -TenantId "xxxxxxxx"
+  ```
+- **Invoke-LMGCPAccountTest**: This cmdlet will test for required permissions needed to add an GCP project to LogicMonitor. 
+  ```
+   Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"
+  ```
 
 ### Updated Cmdlets:
- - **Set-LMDeviceDatasourceInstanceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
- - **Set-LMDeviceGroupDatasourceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
+ - **Get-LMDatasourceUpdateHistory**: Added custom object return type *LogicMonitor.ModuleUpdateHistory*.
+ - **Set-LMDevice**: Added additional parameter `-AutoBalancedCollectorGroupId` to specify an auto balanced collector group.
 
 [Previous Release Notes](RELEASENOTES.md)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,16 @@
+## 6.0
+### New Cmdlets:
+ - **Get-LMDeviceInstanceData**: This cmdlet retrieves data for LogicMonitor device instances based on the specified parameters. The cmdlet can only retrieve data within the last 24 hours. You can use `Get-LMDeviceInstanceList` to quickly get a list of instances for a particular device.
+ - **New-LMAlertEscalation**: This cmdlet invokes an escalation for a LogicMonitor alert. It takes a *-Ids* parameter which is an array of alert ids to escalate.
+ - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
+ 
+ **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.
+
+
+### Updated Cmdlets:
+ - **Set-LMDeviceDatasourceInstanceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
+ - **Set-LMDeviceGroupDatasourceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
+ 
 # Previous module release notes
 ## 5.1.3
 ### Updated Cmdlets:

--- a/en-US/Logic.Monitor-help.xml
+++ b/en-US/Logic.Monitor-help.xml
@@ -543,6 +543,10 @@
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
+        <maml:linkText>Module repo: https://github.com/logicmonitor/lm-powershell-module</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
         <maml:linkText>PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
@@ -1290,6 +1294,10 @@ Creates a copy of the device specified by the $deviceObject variable with the na
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
+        <maml:linkText>Module repo: https://github.com/logicmonitor/lm-powershell-module</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
         <maml:linkText>PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
@@ -1542,6 +1550,10 @@ Creates a copy of the device specified by the $deviceObject variable with the na
       </command:example>
     </command:examples>
     <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Module repo: https://github.com/logicmonitor/lm-powershell-module</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor</maml:linkText>
         <maml:uri></maml:uri>
@@ -2440,10 +2452,242 @@ Creates a copy of the device specified by the $deviceObject variable with the na
     </command:examples>
     <command:relatedLinks>
       <maml:navigationLink>
+        <maml:linkText>Module repo: https://github.com/logicmonitor/lm-powershell-module</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
         <maml:linkText>PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor</maml:linkText>
         <maml:uri></maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-LMAccessGroup</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMAccessGroup</command:noun>
+      <maml:description>
+        <maml:para>Retrieves LogicMonitor access groups based on specified parameters.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMAccessGroup function retrieves LogicMonitor access groups based on the specified parameters. It supports retrieving access groups by ID, name, or using a filter. The function uses the LogicMonitor REST API to make the requests.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Specifies the ID of the access group to retrieve. This parameter is mutually exclusive with the Name and Filter parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of the access group to retrieve. This parameter is mutually exclusive with the Id and Filter parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>Specifies a filter object to retrieve access groups based on custom filter criteria. This parameter is mutually exclusive with the Id and Name parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Specifies the ID of the access group to retrieve. This parameter is mutually exclusive with the Name and Filter parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Specifies the name of the access group to retrieve. This parameter is mutually exclusive with the Id and Filter parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Filter</maml:name>
+        <maml:description>
+          <maml:para>Specifies a filter object to retrieve access groups based on custom filter criteria. This parameter is mutually exclusive with the Id and Name parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1000</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires a valid LogicMonitor API authentication. Use Connect-LMAccount to authenticate before running this function.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMAccessGroup -Id 123
+Retrieves the access group with the specified ID.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-LMAccessGroup -Name "MyAccessGroup"
+Retrieves the access group with the specified name.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Get-LMAccessGroup -Filter @{ Property = "Value" }
+Retrieves access groups based on the specified filter criteria.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
@@ -4073,6 +4317,73 @@ Retrieves audit logs that contain the search string "login" and occurred within 
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-LMAWSAccountId</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMAWSAccountId</command:noun>
+      <maml:description>
+        <maml:para>Retrieves the AWS Account ID associated with the LogicMonitor account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMAWSAccountId function is used to retrieve the AWS Account ID associated with the LogicMonitor account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, and then sends a GET request to the LogicMonitor API to retrieve the AWS Account ID. The function returns the response containing the AWS Account ID.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMAWSAccountId</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMAWSAccountId
+Retrieves the AWS Account ID associated with the LogicMonitor account.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://www.logicmonitor.com/support/rest-api-developers-guide/</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-LMCachedAccount</command:name>
       <command:verb>Get</command:verb>
       <command:noun>LMCachedAccount</command:noun>
@@ -5556,6 +5867,282 @@ Retrieves the configuration source with the name "MyConfigSource".</dev:code>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>Get-LMConfigSource -Filter @{ Property = "Value" }
 Retrieves configuration sources based on the specified filter criteria.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-LMConfigsourceUpdateHistory</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMConfigsourceUpdateHistory</command:noun>
+      <maml:description>
+        <maml:para>Retrieves the update history for a LogicMonitor configuration source.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMConfigsourceUpdateHistory function retrieves the update history for a LogicMonitor configuration source. It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMConfigsourceUpdateHistory</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>The ID of the configuration source. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMConfigsourceUpdateHistory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'Name' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMConfigsourceUpdateHistory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DisplayName</maml:name>
+          <maml:description>
+            <maml:para>The display name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'DisplayName' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>The ID of the configuration source. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>The name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'Name' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DisplayName</maml:name>
+        <maml:description>
+          <maml:para>The display name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'DisplayName' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Filter</maml:name>
+        <maml:description>
+          <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1000</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMConfigsourceUpdateHistory -Id 1234
+Retrieves the update history for the configuration source with the ID 1234.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-LMConfigsourceUpdateHistory -Name "MyConfigSource"
+Retrieves the update history for the configuration source with the name "MyConfigSource".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Get-LMConfigsourceUpdateHistory -DisplayName "My Config Source"
+Retrieves the update history for the configuration source with the display name "My Config Source".</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -8462,101 +9049,50 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
       <command:verb>Get</command:verb>
       <command:noun>LMDatasourceUpdateHistory</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Retrieves the update history of a LogicMonitor datasource.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>The Get-LMDatasourceUpdateHistory function retrieves the update history of a LogicMonitor datasource. It can be used to get information about the updates made to a datasource, such as the reasons for the updates.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>BatchSize</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill BatchSize Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>DisplayName</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill DisplayName Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Filter</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill Filter Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
-          <dev:type>
-            <maml:name>Object</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
-          <maml:name>ProgressAction</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
-          <dev:type>
-            <maml:name>ActionPreference</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>BatchSize</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill BatchSize Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Filter</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill Filter Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
-          <dev:type>
-            <maml:name>Object</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Id</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Id Description }}</maml:para>
+            <maml:para>The ID of the datasource. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that can be used to filter the results. The filter object should contain properties that match the properties of the datasource. Only datasources that match the filter will be included in the results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve in each batch. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
           <maml:name>ProgressAction</maml:name>
@@ -8574,13 +9110,13 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
       <command:syntaxItem>
         <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>BatchSize</maml:name>
+          <maml:name>Name</maml:name>
           <maml:description>
-            <maml:para>{{ Fill BatchSize Description }}</maml:para>
+            <maml:para>The name of the datasource. This parameter is used to look up the ID of the datasource. If the name is provided, the function will automatically retrieve the ID of the datasource. This parameter is used in the 'Name' parameter set.</maml:para>
           </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
-            <maml:name>Int32</maml:name>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8588,7 +9124,7 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Filter</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Filter Description }}</maml:para>
+            <maml:para>A filter object that can be used to filter the results. The filter object should contain properties that match the properties of the datasource. Only datasources that match the filter will be included in the results.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
           <dev:type>
@@ -8598,9 +9134,36 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Name</maml:name>
+          <maml:name>BatchSize</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Name Description }}</maml:para>
+            <maml:para>The number of results to retrieve in each batch. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DisplayName</maml:name>
+          <maml:description>
+            <maml:para>The display name of the datasource. This parameter is used to look up the ID of the datasource. If the display name is provided, the function will automatically retrieve the ID of the datasource. This parameter is used in the 'DisplayName' parameter set.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -8608,6 +9171,30 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that can be used to filter the results. The filter object should contain properties that match the properties of the datasource. Only datasources that match the filter will be included in the results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve in each batch. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
           <maml:name>ProgressAction</maml:name>
@@ -8624,14 +9211,26 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>BatchSize</maml:name>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
         <maml:description>
-          <maml:para>{{ Fill BatchSize Description }}</maml:para>
+          <maml:para>The ID of the datasource. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
           <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>The name of the datasource. This parameter is used to look up the ID of the datasource. If the name is provided, the function will automatically retrieve the ID of the datasource. This parameter is used in the 'Name' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -8639,7 +9238,7 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>DisplayName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DisplayName Description }}</maml:para>
+          <maml:para>The display name of the datasource. This parameter is used to look up the ID of the datasource. If the display name is provided, the function will automatically retrieve the ID of the datasource. This parameter is used in the 'DisplayName' parameter set.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -8651,7 +9250,7 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>Filter</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Filter Description }}</maml:para>
+          <maml:para>A filter object that can be used to filter the results. The filter object should contain properties that match the properties of the datasource. Only datasources that match the filter will be included in the results.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
         <dev:type>
@@ -8660,29 +9259,17 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>Id</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>BatchSize</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Id Description }}</maml:para>
+          <maml:para>The number of results to retrieve in each batch. The default value is 1000.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
           <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>Name</maml:name>
-        <maml:description>
-          <maml:para>{{ Fill Name Description }}</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
+        <dev:defaultValue>1000</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
         <maml:name>ProgressAction</maml:name>
@@ -8697,26 +9284,8 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
-    <command:inputTypes>
-      <command:inputType>
-        <dev:type>
-          <maml:name>None</maml:name>
-        </dev:type>
-        <maml:description>
-          <maml:para></maml:para>
-        </maml:description>
-      </command:inputType>
-    </command:inputTypes>
-    <command:returnValues>
-      <command:returnValue>
-        <dev:type>
-          <maml:name>System.Object</maml:name>
-        </dev:type>
-        <maml:description>
-          <maml:para></maml:para>
-        </maml:description>
-      </command:returnValue>
-    </command:returnValues>
+    <command:inputTypes />
+    <command:returnValues />
     <maml:alertSet>
       <maml:alert>
         <maml:para></maml:para>
@@ -8724,10 +9293,27 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
     </maml:alertSet>
     <command:examples>
       <command:example>
-        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMDatasourceUpdateHistory -Id 1234
+Retrieves the update history of the datasource with ID 1234.</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-LMDatasourceUpdateHistory -Name "MyDatasource"
+Retrieves the update history of the datasource with the name "MyDatasource".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Get-LMDatasourceUpdateHistory -DisplayName "My Datasource"
+Retrieves the update history of the datasource with the display name "My Datasource".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -14738,6 +15324,188 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
         <dev:remarks>
           <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-LMDeviceInstanceData</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMDeviceInstanceData</command:noun>
+      <maml:description>
+        <maml:para>Retrieves data for LogicMonitor device instances.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMDeviceInstanceData function retrieves data for LogicMonitor device instances based on the specified parameters.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMDeviceInstanceData</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>StartDate</maml:name>
+          <maml:description>
+            <maml:para>The start date for the data retrieval. If not specified, the function uses the default value of 24 hours ago which is the max timeframe for this endpoint.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>EndDate</maml:name>
+          <maml:description>
+            <maml:para>The end date for the data retrieval. If not specified, the function uses the current date and time.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="Id">
+          <maml:name>Ids</maml:name>
+          <maml:description>
+            <maml:para>The array of device instance IDs for which to retrieve data. This parameter is mandatory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>AggregationType</maml:name>
+          <maml:description>
+            <maml:para>The type of aggregation to apply to the retrieved data. Valid values are "first", "last", "min", "max", "sum", "average", and "none". The default value is "none".</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+          <maml:name>Period</maml:name>
+          <maml:description>
+            <maml:para>The period for the data retrieval. The default value is 1.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>StartDate</maml:name>
+        <maml:description>
+          <maml:para>The start date for the data retrieval. If not specified, the function uses the default value of 24 hours ago which is the max timeframe for this endpoint.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTime</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>EndDate</maml:name>
+        <maml:description>
+          <maml:para>The end date for the data retrieval. If not specified, the function uses the current date and time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTime</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="Id">
+        <maml:name>Ids</maml:name>
+        <maml:description>
+          <maml:para>The array of device instance IDs for which to retrieve data. This parameter is mandatory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>AggregationType</maml:name>
+        <maml:description>
+          <maml:para>The type of aggregation to apply to the retrieved data. Valid values are "first", "last", "min", "max", "sum", "average", and "none". The default value is "none".</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+        <maml:name>Period</maml:name>
+        <maml:description>
+          <maml:para>The period for the data retrieval. The default value is 1.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires a valid LogicMonitor API authentication. Make sure to log in using Connect-LMAccount before running this command.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMDeviceInstanceData -StartDate (Get-Date).AddHours(-7) -EndDate (Get-Date) -Ids "12345", "67890" -AggregationType "average" -Period 1
+Retrieves data for the device instances with IDs "12345" and "67890" for the past 7 hours, using an average aggregation and a period of 1 day.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -24938,6 +25706,573 @@ Invokes an active discovery task for all devices in the device group with the na
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Invoke-LMAWSAccountTest</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMAWSAccountTest</command:noun>
+      <maml:description>
+        <maml:para>Invokes a test for an AWS account in LogicMonitor.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMAWSAccountTest function is used to invoke a test for an AWS account in LogicMonitor. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test. The function returns the response from the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMAWSAccountTest</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ExternalId</maml:name>
+          <maml:description>
+            <maml:para>The external ID of the AWS account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>AccountId</maml:name>
+          <maml:description>
+            <maml:para>The account ID of the AWS account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>AssumedRoleARN</maml:name>
+          <maml:description>
+            <maml:para>The assumed role ARN of the AWS account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>CheckedServices</maml:name>
+          <maml:description>
+            <maml:para>The list of services to be checked during the test. Default value is a comma-separated string of service names supported by LogicMonitor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>The device group ID to which the AWS account belongs. Default value is -1 for no group.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>-1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ExternalId</maml:name>
+        <maml:description>
+          <maml:para>The external ID of the AWS account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>AccountId</maml:name>
+        <maml:description>
+          <maml:para>The account ID of the AWS account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>AssumedRoleARN</maml:name>
+        <maml:description>
+          <maml:para>The assumed role ARN of the AWS account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>CheckedServices</maml:name>
+        <maml:description>
+          <maml:para>The list of services to be checked during the test. Default value is a comma-separated string of service names supported by LogicMonitor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>The device group ID to which the AWS account belongs. Default value is -1 for no group.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>-1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires the user to be logged in before running any commands. Use the Connect-LMAccount function to log in before invoking this function.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123</dev:code>
+        <dev:remarks>
+          <maml:para>This example invokes a test for an AWS account with the specified parameters.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Invoke-LMAzureAccountTest</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMAzureAccountTest</command:noun>
+      <maml:description>
+        <maml:para>Invokes a test on an Azure account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMAzureAccountTest function is used to invoke a test on an Azure account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, and then sends a POST request to the specified endpoint. The function returns the response from the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMAzureAccountTest</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ClientId</maml:name>
+          <maml:description>
+            <maml:para>The client ID of the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>SecretKey</maml:name>
+          <maml:description>
+            <maml:para>The secret key of the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>CheckedServices</maml:name>
+          <maml:description>
+            <maml:para>The list of services to be checked. Default value is a list of commonly used Azure services.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>SubscriptionIds</maml:name>
+          <maml:description>
+            <maml:para>The subscription IDs associated with the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>The group ID. Default value is -1.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>-1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="none">
+          <maml:name>TenantId</maml:name>
+          <maml:description>
+            <maml:para>The tenant ID of the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
+          <maml:name>IsChinaAccount</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ClientId</maml:name>
+        <maml:description>
+          <maml:para>The client ID of the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>SecretKey</maml:name>
+        <maml:description>
+          <maml:para>The secret key of the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>CheckedServices</maml:name>
+        <maml:description>
+          <maml:para>The list of services to be checked. Default value is a list of commonly used Azure services.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>SubscriptionIds</maml:name>
+        <maml:description>
+          <maml:para>The subscription IDs associated with the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>The group ID. Default value is -1.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>-1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="none">
+        <maml:name>TenantId</maml:name>
+        <maml:description>
+          <maml:para>The tenant ID of the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
+        <maml:name>IsChinaAccount</maml:name>
+        <maml:description>
+          <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMAzureAccountTest -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SubscriptionIds "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"</dev:code>
+        <dev:remarks>
+          <maml:para>This example invokes a test on an Azure account using the specified client ID, secret key, and subscription IDs.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Invoke-LMAzureSubscriptionDiscovery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMAzureSubscriptionDiscovery</command:noun>
+      <maml:description>
+        <maml:para>Invokes the Azure subscription discovery process to return subscriptions for a specified client Id.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMAzureSubscriptionDiscovery function is used to discover Azure subscriptions by making API requests to the LogicMonitor platform.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMAzureSubscriptionDiscovery</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ClientId</maml:name>
+          <maml:description>
+            <maml:para>The client ID of the Azure Active Directory application.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>SecretKey</maml:name>
+          <maml:description>
+            <maml:para>The secret key of the Azure Active Directory application.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>TenantId</maml:name>
+          <maml:description>
+            <maml:para>The tenant ID of the Azure Active Directory application.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>IsChinaAccount</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ClientId</maml:name>
+        <maml:description>
+          <maml:para>The client ID of the Azure Active Directory application.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>SecretKey</maml:name>
+        <maml:description>
+          <maml:para>The secret key of the Azure Active Directory application.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>TenantId</maml:name>
+        <maml:description>
+          <maml:para>The tenant ID of the Azure Active Directory application.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>IsChinaAccount</maml:name>
+        <maml:description>
+          <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Invoke-LMCloudGroupNetScan</command:name>
       <command:verb>Invoke</command:verb>
       <command:noun>LMCloudGroupNetScan</command:noun>
@@ -26107,6 +27442,163 @@ Schedules a configuration collection task for the device with the ID 123, the da
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Invoke-LMGCPAccountTest</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMGCPAccountTest</command:noun>
+      <maml:description>
+        <maml:para>Invokes a test for a GCP (Google Cloud Platform) account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMGCPAccountTest function is used to invoke a test for a GCP account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test. The function returns the response from the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMGCPAccountTest</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ServiceAccountKey</maml:name>
+          <maml:description>
+            <maml:para>The service account key for the GCP account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>The ID of the GCP project.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>CheckedServices</maml:name>
+          <maml:description>
+            <maml:para>(Optional) A comma-separated list of GCP services to be checked. The default value is a list of all LM supported GCP services.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>(Optional) The ID of the group to which the GCP account belongs. The default value is -1, indicating no group.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>-1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ServiceAccountKey</maml:name>
+        <maml:description>
+          <maml:para>The service account key for the GCP account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>The ID of the GCP project.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>CheckedServices</maml:name>
+        <maml:description>
+          <maml:para>(Optional) A comma-separated list of GCP services to be checked. The default value is a list of all LM supported GCP services.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>(Optional) The ID of the group to which the GCP account belongs. The default value is -1, indicating no group.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>-1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires the user to be logged in before running any commands. Use the Connect-LMAccount function to log in before invoking this function.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"</dev:code>
+        <dev:remarks>
+          <maml:para>This example invokes a test for a GCP account using the specified service account key and project ID.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Invoke-LMNetScan</command:name>
       <command:verb>Invoke</command:verb>
       <command:noun>LMNetScan</command:noun>
@@ -26381,6 +27873,92 @@ Invokes a session logoff for the users "user1" and "user2" in Logic Monitor.</de
         <dev:code>New-LMAlertAck -Ids @("12345","67890") -Note "Acknowledging alerts"</dev:code>
         <dev:remarks>
           <maml:para>This example acknowledges the alerts with the IDs "12345" and "67890" and adds the note "Acknowledging alerts" to the acknowledgment.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>New-LMAlertEscalation</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>LMAlertEscalation</command:noun>
+      <maml:description>
+        <maml:para>Creates a new escalation for a LogicMonitor alert.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The New-LMAlertEscalation function creates a new escalation for a LogicMonitor alert. It checks if the user is logged in and has valid API credentials before making the API request to create the escalation.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-LMAlertEscalation</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>The ID of the alert for which the escalation needs to be created.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>The ID of the alert for which the escalation needs to be created.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>New-LMAlertEscalation -Id "DS12345"
+Creates a new escalation for the alert with ID "12345".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -48861,6 +50439,18 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Set-LMDevice</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AutoBalancedCollectorGroupId</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AutoBalancedCollectorGroupId Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:description>
@@ -49095,6 +50685,18 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Set-LMDevice</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AutoBalancedCollectorGroupId</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AutoBalancedCollectorGroupId Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:description>
@@ -49329,6 +50931,18 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AutoBalancedCollectorGroupId</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AutoBalancedCollectorGroupId Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
         <maml:name>Confirm</maml:name>
         <maml:description>
@@ -59554,6 +61168,269 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
         <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
         <dev:remarks>
           <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Set-LMUserdata</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>LMUserdata</command:noun>
+      <maml:description>
+        <maml:para>Sets userdata for a LogicMonitor user. Currently only setting the default dashboard is supported.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Set-LMUserdata function is used to set the user data for a LogicMonitor user. It allows you to specify the user by either their Id or Name, and the dashboard Id for which the user data should be set.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-LMUserdata</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Id of the user. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DashboardId</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-LMUserdata</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Name of the user. This parameter is mandatory when using the 'Name' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DashboardId</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Id of the user. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Name of the user. This parameter is mandatory when using the 'Name' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DashboardId</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None.</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Returns the response from the LogicMonitor API.</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires a valid API authentication. Make sure you are logged in before running any commands using Connect-LMAccount.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Set-LMUserdata -Id "12345" -DashboardId "67890"
+Sets the user data for the user with Id "12345" for the dashboard with Id "67890".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Set-LMUserdata -Name "JohnDoe" -DashboardId "67890"
+Sets the user data for the user with Name "JohnDoe" for the dashboard with Id "67890".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
## 6.1
### New Cmdlets:
 - **Get-LMAWSAccountId**: This cmdlet is used to retrieve the AWS Account ID associated with the LogicMonitor account.
 - **Get-LMConfigsourceUpdateHistory**: This cmdlet retrieves the update history for a LogicMonitor configuration source. It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated..
 - **Invoke-LMAWSAccountTest**: This cmdlet will test for required permissions needed to add an AWS account to LogicMonitor. 
    ```
    Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123
    ```
- **Invoke-LMAzureAccountTest**: This cmdlet will test for required permissions needed to add an Azure account to LogicMonitor. 
  ```
  Invoke-LMAzureAccountTest -ClientId "xxxxxxxx" -SecretKey "xxxxxxxx" -SubscriptionIds "xxxxxxxx"
  ```
- **Invoke-LMAzureSubscriptionDiscovery**: This cmdlet invokes the Azure subscription discovery process to return subscriptions for a specified client Id. 
  ```
    Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx" -SecretKey "xxxxxxxx" -TenantId "xxxxxxxx"
  ```
- **Invoke-LMGCPAccountTest**: This cmdlet will test for required permissions needed to add an GCP project to LogicMonitor. 
  ```
   Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"
  ```

### Updated Cmdlets:
 - **Get-LMDatasourceUpdateHistory**: Added custom object return type *LogicMonitor.ModuleUpdateHistory*.
 - **Set-LMDevice**: Added additional parameter `-AutoBalancedCollectorGroupId` to specify an auto balanced collector group.