### PR TITLE
v6.1 pre release

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -7,25 +7,25 @@ $publicFuncFolderPath = './Public'
 
 $ps1xmlFiles = Get-ChildItem -Path ./ -Filter *.ps1xml
 foreach ($ps1xml in $ps1xmlFiles) {
-  [xml]$xml = Get-Content -Path $ps1xml.FullName
-  $null = $xml.Schemas.Add($null, 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Format.xsd')
-  $null = $xml.Schemas.Add($null, 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Types.xsd')
-  $xml.Validate( { throw "File '$($ps1xml.Name)' schema error: $($_.Message)" })
+    [xml]$xml = Get-Content -Path $ps1xml.FullName
+    $null = $xml.Schemas.Add($null, 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Format.xsd')
+    $null = $xml.Schemas.Add($null, 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Types.xsd')
+    $xml.Validate( { throw "File '$($ps1xml.Name)' schema error: $($_.Message)" })
 }
 
 if (!(Get-PackageProvider | Where-Object { $_.Name -eq 'NuGet' })) {
-    Install-PackageProvider -Name NuGet -force | Out-Null
+    Install-PackageProvider -Name NuGet -Force | Out-Null
 }
-Import-PackageProvider -Name NuGet -force | Out-Null
+Import-PackageProvider -Name NuGet -Force | Out-Null
 
 if ((Get-PSRepository -Name PSGallery).InstallationPolicy -ne 'Trusted') {
     Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 }
 
-if(!(Get-Module Microsoft.PowerShell.SecretManagement -ListAvailable)){
+if (!(Get-Module Microsoft.PowerShell.SecretManagement -ListAvailable)) {
     Install-Module Microsoft.PowerShell.SecretManagement -Force -Confirm:$false
 }
-if(!(Get-Module Microsoft.PowerShell.SecretStore -ListAvailable)){
+if (!(Get-Module Microsoft.PowerShell.SecretStore -ListAvailable)) {
     Install-Module Microsoft.PowerShell.SecretStore -Force -Confirm:$false
 }
 
@@ -33,7 +33,8 @@ $manifestContent = (Get-Content -Path $manifestPath -Raw) -replace '<ModuleVersi
 
 if ((Test-Path -Path $publicFuncFolderPath) -and ($publicFunctionNames = Get-ChildItem -Path $publicFuncFolderPath -Filter '*.ps1' | Select-Object -ExpandProperty BaseName)) {
     $funcStrings = "'$($publicFunctionNames -join "','")'"
-} else {
+}
+else {
     $funcStrings = $null
 }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -6,35 +6,35 @@ $manifestPath = "./Logic.Monitor.psd1"
 $publicFuncFolderPath = './Public'
 
 $ps1xmlFiles = Get-ChildItem -Path ./ -Filter *.ps1xml
-foreach ($ps1xml in $ps1xmlFiles) {
+Foreach ($ps1xml in $ps1xmlFiles) {
     [xml]$xml = Get-Content -Path $ps1xml.FullName
     $null = $xml.Schemas.Add($null, 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Format.xsd')
     $null = $xml.Schemas.Add($null, 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/src/Schemas/Types.xsd')
-    $xml.Validate( { throw "File '$($ps1xml.Name)' schema error: $($_.Message)" })
+    $xml.Validate( { Throw "File '$($ps1xml.Name)' schema error: $($_.Message)" })
 }
 
-if (!(Get-PackageProvider | Where-Object { $_.Name -eq 'NuGet' })) {
+If (!(Get-PackageProvider | Where-Object { $_.Name -eq 'NuGet' })) {
     Install-PackageProvider -Name NuGet -Force | Out-Null
 }
 Import-PackageProvider -Name NuGet -Force | Out-Null
 
-if ((Get-PSRepository -Name PSGallery).InstallationPolicy -ne 'Trusted') {
+If ((Get-PSRepository -Name PSGallery).InstallationPolicy -ne 'Trusted') {
     Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 }
 
-if (!(Get-Module Microsoft.PowerShell.SecretManagement -ListAvailable)) {
+If (!(Get-Module Microsoft.PowerShell.SecretManagement -ListAvailable)) {
     Install-Module Microsoft.PowerShell.SecretManagement -Force -Confirm:$false
 }
-if (!(Get-Module Microsoft.PowerShell.SecretStore -ListAvailable)) {
+If (!(Get-Module Microsoft.PowerShell.SecretStore -ListAvailable)) {
     Install-Module Microsoft.PowerShell.SecretStore -Force -Confirm:$false
 }
 
 $manifestContent = (Get-Content -Path $manifestPath -Raw) -replace '<ModuleVersion>', $buildVersion
 
-if ((Test-Path -Path $publicFuncFolderPath) -and ($publicFunctionNames = Get-ChildItem -Path $publicFuncFolderPath -Filter '*.ps1' | Select-Object -ExpandProperty BaseName)) {
+If ((Test-Path -Path $publicFuncFolderPath) -and ($publicFunctionNames = Get-ChildItem -Path $publicFuncFolderPath -Filter '*.ps1' | Select-Object -ExpandProperty BaseName)) {
     $funcStrings = "'$($publicFunctionNames -join "','")'"
 }
-else {
+Else {
     $funcStrings = $null
 }
 

--- a/Documentation/Disconnect-LMAccount.md
+++ b/Documentation/Disconnect-LMAccount.md
@@ -13,7 +13,7 @@ Disconnect from a previously connected LM portal
 ## SYNTAX
 
 ```
-Disconnect-LMAccount
+Disconnect-LMAccount [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,6 +28,9 @@ Disconnect-LMAccount
 ```
 
 ## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/Documentation/Get-LMAWSAccountId.md
+++ b/Documentation/Get-LMAWSAccountId.md
@@ -1,0 +1,59 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version: https://www.logicmonitor.com/support/rest-api-developers-guide/
+schema: 2.0.0
+---
+
+# Get-LMAWSAccountId
+
+## SYNOPSIS
+Retrieves the AWS Account ID associated with the LogicMonitor account.
+
+## SYNTAX
+
+```
+Get-LMAWSAccountId [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-LMAWSAccountId function is used to retrieve the AWS Account ID associated with the LogicMonitor account.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, and then sends a GET request to the LogicMonitor API to retrieve the AWS Account ID.
+The function returns the response containing the AWS Account ID.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-LMAWSAccountId
+Retrieves the AWS Account ID associated with the LogicMonitor account.
+```
+
+## PARAMETERS
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Documentation/Get-LMAccessGroup.md
+++ b/Documentation/Get-LMAccessGroup.md
@@ -55,7 +55,7 @@ Retrieves the access group with the specified name.
 
 ### EXAMPLE 3
 ```
-Get-LMAccessGroup -Filter @{ Property = "Value" }
+Get-LMAccessGroup -Filter "tenantId -eq 'Value'"
 Retrieves access groups based on the specified filter criteria.
 ```
 

--- a/Documentation/Get-LMAccountStatus.md
+++ b/Documentation/Get-LMAccountStatus.md
@@ -13,7 +13,7 @@ Retrieves the status of the LogicMonitor account.
 ## SYNTAX
 
 ```
-Get-LMAccountStatus
+Get-LMAccountStatus [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +30,9 @@ Get-LMAccountStatus
 This example demonstrates how to use the Get-LMAccountStatus function to retrieve the status of the LogicMonitor account.
 
 ## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/Documentation/Get-LMConfigsourceUpdateHistory.md
+++ b/Documentation/Get-LMConfigsourceUpdateHistory.md
@@ -5,47 +5,60 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# Get-LMConfigsourceUpdateHistory
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Retrieves the update history for a LogicMonitor configuration source.
 
 ## SYNTAX
 
 ### Id (Default)
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMConfigsourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Name
 ```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMConfigsourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### DisplayName
 ```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMConfigsourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Get-LMConfigsourceUpdateHistory function retrieves the update history for a LogicMonitor configuration source.
+It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Get-LMConfigsourceUpdateHistory -Id 1234
+Retrieves the update history for the configuration source with the ID 1234.
 ```
 
-{{ Add example description here }}
+### EXAMPLE 2
+```
+Get-LMConfigsourceUpdateHistory -Name "MyConfigSource"
+Retrieves the update history for the configuration source with the name "MyConfigSource".
+```
+
+### EXAMPLE 3
+```
+Get-LMConfigsourceUpdateHistory -DisplayName "My Config Source"
+Retrieves the update history for the configuration source with the display name "My Config Source".
+```
 
 ## PARAMETERS
 
 ### -Id
-{{ Fill Id Description }}
+The ID of the configuration source.
+This parameter is mandatory when using the 'Id' parameter set.
 
 ```yaml
 Type: Int32
@@ -54,13 +67,15 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Name
-{{ Fill Name Description }}
+The name of the configuration source.
+This parameter is used to look up the ID of the configuration source.
+This parameter is used when using the 'Name' parameter set.
 
 ```yaml
 Type: String
@@ -75,7 +90,9 @@ Accept wildcard characters: False
 ```
 
 ### -DisplayName
-{{ Fill DisplayName Description }}
+The display name of the configuration source.
+This parameter is used to look up the ID of the configuration source.
+This parameter is used when using the 'DisplayName' parameter set.
 
 ```yaml
 Type: String
@@ -90,7 +107,8 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-{{ Fill Filter Description }}
+A filter object that specifies additional filtering criteria for the update history.
+This parameter is optional.
 
 ```yaml
 Type: Object
@@ -105,7 +123,9 @@ Accept wildcard characters: False
 ```
 
 ### -BatchSize
-{{ Fill BatchSize Description }}
+The number of results to retrieve per request.
+The default value is 1000.
+This parameter is optional.
 
 ```yaml
 Type: Int32
@@ -114,7 +134,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 1000
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -139,10 +159,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
 ## OUTPUTS
 
-### System.Object
 ## NOTES
 
 ## RELATED LINKS

--- a/Documentation/Get-LMDeviceDatasourceInstance.md
+++ b/Documentation/Get-LMDeviceDatasourceInstance.md
@@ -8,80 +8,57 @@ schema: 2.0.0
 # Get-LMDeviceDatasourceInstance
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Retrieves instances of a LogicMonitor device datasource.
 
 ## SYNTAX
 
 ### Name-dsName
 ```
-Get-LMDeviceDatasourceInstance -DatasourceName <String> -DeviceName <String> [-Filter <Object>]
- [-BatchSize <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-LMDeviceDatasourceInstance -DatasourceName <String> -Name <String> [-Filter <Object>] [-BatchSize <Int32>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Id-dsName
 ```
-Get-LMDeviceDatasourceInstance -DatasourceName <String> -DeviceId <Int32> [-Filter <Object>]
- [-BatchSize <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-LMDeviceDatasourceInstance -DatasourceName <String> -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Name-dsId
 ```
-Get-LMDeviceDatasourceInstance -DatasourceId <Int32> -DeviceName <String> [-Filter <Object>]
- [-BatchSize <Int32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-LMDeviceDatasourceInstance -DatasourceId <Int32> -Name <String> [-Filter <Object>] [-BatchSize <Int32>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Id-dsId
 ```
-Get-LMDeviceDatasourceInstance -DatasourceId <Int32> -DeviceId <Int32> [-Filter <Object>] [-BatchSize <Int32>]
+Get-LMDeviceDatasourceInstance -DatasourceId <Int32> -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Get-LMDeviceDatasourceInstance function retrieves instances of a LogicMonitor device datasource based on the specified parameters.
+It requires a valid API authentication and authorization.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Get-LMDeviceDatasourceInstance -DatasourceName "CPU" -Name "Server01" -BatchSize 500
+Retrieves instances of the "CPU" datasource for the device named "Server01" with a batch size of 500.
 ```
 
-{{ Add example description here }}
+### EXAMPLE 2
+```
+Get-LMDeviceDatasourceInstance -DatasourceId 1234 -Id 5678
+Retrieves instances of the datasource with ID 1234 for the device with ID 5678.
+```
 
 ## PARAMETERS
 
-### -BatchSize
-{{ Fill BatchSize Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DatasourceId
-{{ Fill DatasourceId Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: Name-dsId, Id-dsId
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DatasourceName
-{{ Fill DatasourceName Description }}
+Specifies the name of the datasource.
+This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter sets.
 
 ```yaml
 Type: String
@@ -95,28 +72,48 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DeviceId
-{{ Fill DeviceId Description }}
+### -DatasourceId
+Specifies the ID of the datasource.
+This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter sets.
 
 ```yaml
 Type: Int32
-Parameter Sets: Id-dsName, Id-dsId
-Aliases: Id
+Parameter Sets: Name-dsId, Id-dsId
+Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DeviceName
-{{ Fill DeviceName Description }}
+### -Id
+Specifies the ID of the device.
+This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets.
+It can also be specified using the 'DeviceId' alias.
+
+```yaml
+Type: Int32
+Parameter Sets: Id-dsName, Id-dsId
+Aliases: DeviceId
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name of the device.
+This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets.
+It can also be specified using the 'DeviceName' alias.
 
 ```yaml
 Type: String
 Parameter Sets: Name-dsName, Name-dsId
-Aliases: Name
+Aliases: DeviceName
 
 Required: True
 Position: Named
@@ -126,7 +123,8 @@ Accept wildcard characters: False
 ```
 
 ### -Filter
-{{ Fill Filter Description }}
+Specifies additional filters to apply to the instances.
+This parameter accepts an object representing the filter criteria.
 
 ```yaml
 Type: Object
@@ -136,6 +134,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BatchSize
+Specifies the number of instances to retrieve per batch.
+The default value is 1000.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 1000
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -160,10 +174,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
 ## OUTPUTS
 
-### System.Object
 ## NOTES
+This function requires a valid API authentication and authorization.
+Use Connect-LMAccount to log in before running any commands.
 
 ## RELATED LINKS

--- a/Documentation/Get-LMDeviceDatasourceInstanceAlertRecipients.md
+++ b/Documentation/Get-LMDeviceDatasourceInstanceAlertRecipients.md
@@ -5,29 +5,35 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# Get-LMDeviceDatasourceInstanceAlertRecipients
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
 
 ## SYNTAX
 
-### Id (Default)
+### Name-dsName
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### Name
-```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceName <String> -Name <String> -InstanceName <String>
+ -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
-### DisplayName
+### Id-dsName
 ```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceName <String> -Id <Int32> -InstanceName <String>
+ -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### Name-dsId
+```
+Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceId <Int32> -Name <String> -InstanceName <String>
+ -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### Id-dsId
+```
+Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceId <Int32> -Id <Int32> -InstanceName <String>
+ -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,12 +50,72 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
+### -DataPointName
+{{ Fill DataPointName Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DatasourceId
+{{ Fill DatasourceId Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: Name-dsId, Id-dsId
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DatasourceName
+{{ Fill DatasourceName Description }}
+
+```yaml
+Type: String
+Parameter Sets: Name-dsName, Id-dsName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Id
 {{ Fill Id Description }}
 
 ```yaml
 Type: Int32
-Parameter Sets: Id
+Parameter Sets: Id-dsName, Id-dsId
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InstanceName
+{{ Fill InstanceName Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
 Aliases:
 
 Required: True
@@ -64,55 +130,10 @@ Accept wildcard characters: False
 
 ```yaml
 Type: String
-Parameter Sets: Name
+Parameter Sets: Name-dsName, Name-dsId
 Aliases:
 
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisplayName
-{{ Fill DisplayName Description }}
-
-```yaml
-Type: String
-Parameter Sets: DisplayName
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Filter
-{{ Fill Filter Description }}
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BatchSize
-{{ Fill BatchSize Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Documentation/Get-LMDeviceDatasourceInstanceAlertSetting.md
+++ b/Documentation/Get-LMDeviceDatasourceInstanceAlertSetting.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-LMDeviceDatasourceInstanceAlertSetting
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Retrieves the alert settings for a specific LogicMonitor device datasource instance.
 
 ## SYNTAX
 
@@ -37,51 +37,30 @@ Get-LMDeviceDatasourceInstanceAlertSetting -DatasourceId <Int32> -Id <Int32> -In
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Get-LMDeviceDatasourceInstanceAlertSetting function retrieves the alert settings for a specific LogicMonitor device datasource instance.
+It requires the device name or ID, datasource name or ID, and instance name as input parameters.
+Optionally, you can also provide a filter to narrow down the results.
+The function returns an array of alert settings for the specified instance.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Get-LMDeviceDatasourceInstanceAlertSetting -Name "MyDevice" -DatasourceName "MyDatasource" -InstanceName "MyInstance"
+Retrieves the alert settings for the instance named "MyInstance" of the datasource "MyDatasource" on the device named "MyDevice".
 ```
 
-{{ Add example description here }}
+### EXAMPLE 2
+```
+Get-LMDeviceDatasourceInstanceAlertSetting -Id 123 -DatasourceId 456 -InstanceName "MyInstance" -Filter "Property -eq 'value'"
+Retrieves the alert settings for the instance named "MyInstance" of the datasource with ID 456 on the device with ID 123, applying the specified filter.
+```
 
 ## PARAMETERS
 
-### -BatchSize
-{{ Fill BatchSize Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DatasourceId
-{{ Fill DatasourceId Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: Name-dsId, Id-dsId
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -DatasourceName
-{{ Fill DatasourceName Description }}
+Specifies the name of the datasource.
+This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter set.
 
 ```yaml
 Type: String
@@ -95,8 +74,75 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -DatasourceId
+Specifies the ID of the datasource.
+This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter set.
+
+```yaml
+Type: Int32
+Parameter Sets: Name-dsId, Id-dsId
+Aliases:
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies the ID of the device.
+This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter set.
+This parameter can also be specified using the 'DeviceId' alias.
+
+```yaml
+Type: Int32
+Parameter Sets: Id-dsName, Id-dsId
+Aliases: DeviceId
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name of the device.
+This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter set.
+This parameter can also be specified using the 'DeviceName' alias.
+
+```yaml
+Type: String
+Parameter Sets: Name-dsName, Name-dsId
+Aliases: DeviceName
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InstanceName
+Specifies the name of the instance for which to retrieve the alert settings.
+This parameter is mandatory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Filter
-{{ Fill Filter Description }}
+Specifies a filter to narrow down the results.
+This parameter is optional.
 
 ```yaml
 Type: Object
@@ -110,47 +156,19 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Id
-{{ Fill Id Description }}
+### -BatchSize
+Specifies the number of results to retrieve per batch.
+The default value is 1000.
+This parameter is optional.
 
 ```yaml
 Type: Int32
-Parameter Sets: Id-dsName, Id-dsId
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InstanceName
-{{ Fill InstanceName Description }}
-
-```yaml
-Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Name
-{{ Fill Name Description }}
-
-```yaml
-Type: String
-Parameter Sets: Name-dsName, Name-dsId
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
+Default value: 1000
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -175,10 +193,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
 ## OUTPUTS
 
-### System.Object
 ## NOTES
+This function requires a valid LogicMonitor API authentication.
+Make sure you are logged in before running any commands by using the Connect-LMAccount function.
 
 ## RELATED LINKS

--- a/Documentation/Get-LMDeviceDatasourceInstanceGroup.md
+++ b/Documentation/Get-LMDeviceDatasourceInstanceGroup.md
@@ -143,7 +143,7 @@ Accept wildcard characters: False
 ```yaml
 Type: Int32
 Parameter Sets: Id-dsName, Id-dsId, Id-HdsId
-Aliases:
+Aliases: DeviceId
 
 Required: True
 Position: Named
@@ -158,7 +158,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: Name-dsName, Name-dsId, Name-HdsId
-Aliases:
+Aliases: DeviceName
 
 Required: True
 Position: Named

--- a/Documentation/Get-LMDeviceDatasourceList.md
+++ b/Documentation/Get-LMDeviceDatasourceList.md
@@ -74,7 +74,7 @@ Accept wildcard characters: False
 ```yaml
 Type: Int32
 Parameter Sets: Id
-Aliases:
+Aliases: DeviceId
 
 Required: True
 Position: Named
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: Name
-Aliases:
+Aliases: DeviceName
 
 Required: False
 Position: Named

--- a/Documentation/Invoke-LMAWSAccountTest.md
+++ b/Documentation/Invoke-LMAWSAccountTest.md
@@ -1,0 +1,140 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMAWSAccountTest
+
+## SYNOPSIS
+Invokes a test for an AWS account in LogicMonitor.
+
+## SYNTAX
+
+```
+Invoke-LMAWSAccountTest [-ExternalId] <String> [[-AccountId] <String>] [-AssumedRoleARN] <String>
+ [[-CheckedServices] <String>] [[-GroupId] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMAWSAccountTest function is used to invoke a test for an AWS account in LogicMonitor.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test.
+The function returns the response from the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123
+```
+
+This example invokes a test for an AWS account with the specified parameters.
+
+## PARAMETERS
+
+### -ExternalId
+The external ID of the AWS account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AccountId
+The account ID of the AWS account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AssumedRoleARN
+The assumed role ARN of the AWS account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckedServices
+The list of services to be checked during the test.
+Default value is a comma-separated string of service names supported by LogicMonitor.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+The device group ID to which the AWS account belongs.
+Default value is -1 for no group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: -1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+This function requires the user to be logged in before running any commands.
+Use the Connect-LMAccount function to log in before invoking this function.
+
+## RELATED LINKS

--- a/Documentation/Invoke-LMAzureAccountTest.md
+++ b/Documentation/Invoke-LMAzureAccountTest.md
@@ -1,0 +1,170 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMAzureAccountTest
+
+## SYNOPSIS
+Invokes a test on an Azure account.
+
+## SYNTAX
+
+```
+Invoke-LMAzureAccountTest [-ClientId] <String> [-SecretKey] <String> [[-CheckedServices] <String>]
+ [-SubscriptionIds] <String> [[-GroupId] <String>] [-TenantId] <String> [[-IsChinaAccount] <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMAzureAccountTest function is used to invoke a test on an Azure account.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, and then sends a POST request to the specified endpoint.
+The function returns the response from the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMAzureAccountTest -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SubscriptionIds "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+This example invokes a test on an Azure account using the specified client ID, secret key, and subscription IDs.
+
+## PARAMETERS
+
+### -ClientId
+The client ID of the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SecretKey
+The secret key of the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckedServices
+The list of services to be checked.
+Default value is a list of commonly used Azure services.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SubscriptionIds
+The subscription IDs associated with the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+The group ID.
+Default value is -1.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: -1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TenantId
+The tenant ID of the Azure account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsChinaAccount
+Specifies whether the Azure account is a China account.
+Default value is $false.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/Documentation/Invoke-LMAzureSubscriptionDiscovery.md
+++ b/Documentation/Invoke-LMAzureSubscriptionDiscovery.md
@@ -5,116 +5,87 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# Invoke-LMAzureSubscriptionDiscovery
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Invokes the Azure subscription discovery process to return subscriptions for a specified client Id.
 
 ## SYNTAX
 
-### Id (Default)
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### Name
-```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### DisplayName
-```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Invoke-LMAzureSubscriptionDiscovery [-ClientId] <String> [-SecretKey] <String> [-TenantId] <String>
+ [[-IsChinaAccount] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Invoke-LMAzureSubscriptionDiscovery function is used to discover Azure subscriptions by making API requests to the LogicMonitor platform.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
 ```
-
-{{ Add example description here }}
+Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
 
 ## PARAMETERS
 
-### -Id
-{{ Fill Id Description }}
+### -ClientId
+The client ID of the Azure Active Directory application.
 
 ```yaml
-Type: Int32
-Parameter Sets: Id
+Type: String
+Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Name
-{{ Fill Name Description }}
+### -SecretKey
+The secret key of the Azure Active Directory application.
 
 ```yaml
 Type: String
-Parameter Sets: Name
+Parameter Sets: (All)
 Aliases:
 
-Required: False
-Position: Named
+Required: True
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisplayName
-{{ Fill DisplayName Description }}
+### -TenantId
+The tenant ID of the Azure Active Directory application.
 
 ```yaml
 Type: String
-Parameter Sets: DisplayName
+Parameter Sets: (All)
 Aliases:
 
-Required: False
-Position: Named
+Required: True
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Filter
-{{ Fill Filter Description }}
+### -IsChinaAccount
+Specifies whether the Azure account is a China account.
+Default value is $false.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BatchSize
-{{ Fill BatchSize Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
+Position: 4
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -139,10 +110,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
 ## OUTPUTS
 
-### System.Object
 ## NOTES
 
 ## RELATED LINKS

--- a/Documentation/Invoke-LMGCPAccountTest.md
+++ b/Documentation/Invoke-LMGCPAccountTest.md
@@ -1,0 +1,125 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Invoke-LMGCPAccountTest
+
+## SYNOPSIS
+Invokes a test for a GCP (Google Cloud Platform) account.
+
+## SYNTAX
+
+```
+Invoke-LMGCPAccountTest [-ServiceAccountKey] <String> [-ProjectId] <String> [[-CheckedServices] <String>]
+ [[-GroupId] <String>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Invoke-LMGCPAccountTest function is used to invoke a test for a GCP account.
+It checks if the user is logged in and has valid API credentials.
+If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test.
+The function returns the response from the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"
+```
+
+This example invokes a test for a GCP account using the specified service account key and project ID.
+
+## PARAMETERS
+
+### -ServiceAccountKey
+The service account key for the GCP account.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+The ID of the GCP project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckedServices
+(Optional) A comma-separated list of GCP services to be checked.
+The default value is a list of all LM supported GCP services.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -GroupId
+(Optional) The ID of the group to which the GCP account belongs.
+The default value is -1, indicating no group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: -1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+This function requires the user to be logged in before running any commands.
+Use the Connect-LMAccount function to log in before invoking this function.
+
+## RELATED LINKS

--- a/Documentation/New-LMAccessGroup.md
+++ b/Documentation/New-LMAccessGroup.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # New-LMAccessGroup
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Creates a new LogicMonitor access group.
 
 ## SYNTAX
 
@@ -18,36 +18,23 @@ New-LMAccessGroup [-Name] <String> [[-Description] <String>] [[-Tenant] <String>
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The New-LMAccessGroup function is used to create a new access group in LogicMonitor.
+An access group is a collection of users with similar permissions and access rights for managing modules in the LM exchange and my module toolbox.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+New-LMAccessGroup -Name "Group1" -Description "Access group for administrators" -Tenant "12345"
 ```
 
-{{ Add example description here }}
+This example creates a new access group named "Group1" with the description "Access group for administrators" and assigns it to the tenant with ID "12345".
 
 ## PARAMETERS
 
-### -Description
-{{ Fill Description Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Name
-{{ Fill Name Description }}
+The name of the access group.
+This parameter is mandatory.
 
 ```yaml
 Type: String
@@ -55,14 +42,14 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Tenant
-{{ Fill Tenant Description }}
+### -Description
+The description of the access group.
 
 ```yaml
 Type: String
@@ -71,6 +58,21 @@ Aliases:
 
 Required: False
 Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+The ID of the tenant to which the access group belongs.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -96,10 +98,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
 ## OUTPUTS
 
-### System.Object
 ## NOTES
+For this function to work, you need to be logged in and have valid API credentials.
+Use the Connect-LMAccount function to log in before running any commands.
 
 ## RELATED LINKS

--- a/Documentation/New-LMAccessGroup.md
+++ b/Documentation/New-LMAccessGroup.md
@@ -5,28 +5,15 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# New-LMAccessGroup
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
 
 ## SYNTAX
 
-### Id (Default)
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### Name
-```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### DisplayName
-```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
+New-LMAccessGroup [-Name] <String> [[-Description] <String>] [[-Tenant] <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -44,16 +31,16 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
-### -Id
-{{ Fill Id Description }}
+### -Description
+{{ Fill Description Description }}
 
 ```yaml
-Type: Int32
-Parameter Sets: Id
+Type: String
+Parameter Sets: (All)
 Aliases:
 
-Required: True
-Position: Named
+Required: False
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -64,56 +51,26 @@ Accept wildcard characters: False
 
 ```yaml
 Type: String
-Parameter Sets: Name
+Parameter Sets: (All)
 Aliases:
 
-Required: False
-Position: Named
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisplayName
-{{ Fill DisplayName Description }}
+### -Tenant
+{{ Fill Tenant Description }}
 
 ```yaml
 Type: String
-Parameter Sets: DisplayName
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Filter
-{{ Fill Filter Description }}
-
-```yaml
-Type: Object
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BatchSize
-{{ Fill BatchSize Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Documentation/New-LMDeviceDatasourceInstance.md
+++ b/Documentation/New-LMDeviceDatasourceInstance.md
@@ -220,7 +220,7 @@ Mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets.
 ```yaml
 Type: Int32
 Parameter Sets: Id-dsName, Id-dsId
-Aliases:
+Aliases: DeviceId
 
 Required: True
 Position: Named
@@ -236,7 +236,7 @@ Mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets.
 ```yaml
 Type: String
 Parameter Sets: Name-dsName, Name-dsId
-Aliases:
+Aliases: DeviceName
 
 Required: True
 Position: Named

--- a/Documentation/New-LMDeviceDatasourceInstanceGroup.md
+++ b/Documentation/New-LMDeviceDatasourceInstanceGroup.md
@@ -126,7 +126,7 @@ This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter se
 ```yaml
 Type: Int32
 Parameter Sets: Id-dsName, Id-dsId
-Aliases:
+Aliases: DeviceId
 
 Required: True
 Position: Named
@@ -142,7 +142,7 @@ This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' paramete
 ```yaml
 Type: String
 Parameter Sets: Name-dsName, Name-dsId
-Aliases:
+Aliases: DeviceName
 
 Required: True
 Position: Named

--- a/Documentation/Remove-LMAccessGroup.md
+++ b/Documentation/Remove-LMAccessGroup.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Remove-LMAccessGroup
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Removes a LogicMonitor access group.
 
 ## SYNTAX
 
@@ -24,36 +24,27 @@ Remove-LMAccessGroup -Name <String> [-ProgressAction <ActionPreference>] [-WhatI
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Remove-LMAccessGroup function removes a LogicMonitor access group based on the specified ID or name.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Remove-LMAccessGroup -Id 123
+Removes the access group with the ID 123.
 ```
 
-{{ Add example description here }}
+### EXAMPLE 2
+```
+Remove-LMAccessGroup -Name "MyAccessGroup"
+Removes the access group with the name "MyAccessGroup".
+```
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Id
-{{ Fill Id Description }}
+The ID of the access group to remove.
+This parameter is mandatory when using the 'Id' parameter set.
 
 ```yaml
 Type: Int32
@@ -62,13 +53,14 @@ Aliases:
 
 Required: True
 Position: Named
-Default value: None
+Default value: 0
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -Name
-{{ Fill Name Description }}
+The name of the access group to remove.
+This parameter is mandatory when using the 'Name' parameter set.
 
 ```yaml
 Type: String
@@ -98,6 +90,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ProgressAction
 {{ Fill ProgressAction Description }}
 
@@ -118,10 +125,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Int32
+### None.
 ## OUTPUTS
 
-### System.Object
+### System.Management.Automation.PSCustomObject
 ## NOTES
+This function requires a valid LogicMonitor API authentication.
+Make sure to log in using Connect-LMAccount before running this command.
 
 ## RELATED LINKS

--- a/Documentation/Remove-LMAccessGroup.md
+++ b/Documentation/Remove-LMAccessGroup.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# Remove-LMAccessGroup
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
@@ -14,20 +14,13 @@ schema: 2.0.0
 
 ### Id (Default)
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Remove-LMAccessGroup -Id <Int32> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Name
 ```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### DisplayName
-```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Remove-LMAccessGroup -Name <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,6 +37,21 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Id
 {{ Fill Id Description }}
 
@@ -55,7 +63,7 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -67,50 +75,21 @@ Type: String
 Parameter Sets: Name
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisplayName
-{{ Fill DisplayName Description }}
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
 
 ```yaml
-Type: String
-Parameter Sets: DisplayName
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Filter
-{{ Fill Filter Description }}
-
-```yaml
-Type: Object
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -BatchSize
-{{ Fill BatchSize Description }}
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
+Aliases: wi
 
 Required: False
 Position: Named
@@ -139,7 +118,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.Int32
 ## OUTPUTS
 
 ### System.Object

--- a/Documentation/Remove-LMDeviceDatasourceInstance.md
+++ b/Documentation/Remove-LMDeviceDatasourceInstance.md
@@ -15,25 +15,25 @@ Removes a device datasource instance from Logic Monitor.
 ### Name-dsName
 ```
 Remove-LMDeviceDatasourceInstance -DatasourceName <String> -DeviceName <String> [-WildValue <String>]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-InstanceId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Id-dsName
 ```
 Remove-LMDeviceDatasourceInstance -DatasourceName <String> -DeviceId <Int32> [-WildValue <String>]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-InstanceId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Name-dsId
 ```
 Remove-LMDeviceDatasourceInstance -DatasourceId <Int32> -DeviceName <String> [-WildValue <String>]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-InstanceId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Id-dsId
 ```
 Remove-LMDeviceDatasourceInstance -DatasourceId <Int32> -DeviceId <Int32> [-WildValue <String>]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-InstanceId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,13 +44,13 @@ It requires valid API credentials and the user must be logged in before running 
 
 ### EXAMPLE 1
 ```
-Remove-LMDeviceDatasourceInstance -DeviceName "MyDevice" -DatasourceName "MyDatasource" -WildValue "12345"
+Remove-LMDeviceDatasourceInstance -Name "MyDevice" -DatasourceName "MyDatasource" -WildValue "12345"
 Removes the device datasource instance with the specified device name, datasource name, and wildcard value.
 ```
 
 ### EXAMPLE 2
 ```
-Remove-LMDeviceDatasourceInstance -DeviceId 123 -DatasourceId 456 -WildValue "67890"
+Remove-LMDeviceDatasourceInstance -Id 123 -DatasourceId 456 -WildValue "67890"
 Removes the device datasource instance with the specified device ID, datasource ID, and wildcard value.
 ```
 
@@ -101,8 +101,7 @@ Accept wildcard characters: False
 ```
 
 ### -DeviceId
-Specifies the ID of the device.
-This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets.
+{{ Fill DeviceId Description }}
 
 ```yaml
 Type: Int32
@@ -129,8 +128,7 @@ Accept wildcard characters: False
 ```
 
 ### -DeviceName
-Specifies the name of the device.
-This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets.
+{{ Fill DeviceName Description }}
 
 ```yaml
 Type: String
@@ -155,6 +153,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -InstanceId
+{{ Fill InstanceId Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: Id
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```

--- a/Documentation/Remove-LMDeviceDatasourceInstanceGroup.md
+++ b/Documentation/Remove-LMDeviceDatasourceInstanceGroup.md
@@ -5,61 +5,59 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDeviceDatasourceInstanceAlertRecipients
+# Remove-LMDeviceDatasourceInstanceGroup
 
 ## SYNOPSIS
-Retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
+Removes a LogicMonitor device datasource instance group.
 
 ## SYNTAX
 
 ### Name-dsName
 ```
-Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceName <String> -Name <String> -InstanceName <String>
- -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceName <String> -Name <String> -InstanceGroupName <String>
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Id-dsName
 ```
-Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceName <String> -Id <Int32> -InstanceName <String>
- -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceName <String> -Id <Int32> -InstanceGroupName <String>
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Name-dsId
 ```
-Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceId <Int32> -Name <String> -InstanceName <String>
- -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceId <Int32> -Name <String> -InstanceGroupName <String>
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Id-dsId
 ```
-Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceId <Int32> -Id <Int32> -InstanceName <String>
- -DataPointName <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceId <Int32> -Id <Int32> -InstanceGroupName <String>
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-LMDeviceDatasourceInstanceAlertRecipients function retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
+The Remove-LMDeviceDatasourceInstanceGroup function removes a LogicMonitor device datasource instance group based on the provided parameters.
 It requires valid API credentials and a logged-in session.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceName "Ping-" -Name "Server01" -InstanceName "Instance01" -DataPointName "PingLossPercent"
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceName "CPU" -Name "Server01" -InstanceGroupName "Group1"
+Removes the instance group named "Group1" associated with the "CPU" datasource on the device named "Server01".
 ```
-
-Retrieves the alert recipients for the "PingLossPercent" data point in the "CPU" datasource instance of the "Server01" device.
 
 ### EXAMPLE 2
 ```
-Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceId 123 -Id 456 -InstanceName "Instance01" -DataPointName "PingLossPercent"
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceId 123 -Id 456 -InstanceGroupName "Group2"
+Removes the instance group named "Group2" associated with the datasource ID 123 on the device ID 456.
 ```
-
-Retrieves the alert recipients for the "PingLossPercent" data point in the datasource instance with ID 123 of the device with ID 456.
 
 ## PARAMETERS
 
 ### -DatasourceName
-Specifies the name of the datasource.
+Specifies the name of the datasource associated with the instance group.
 This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter sets.
 
 ```yaml
@@ -75,7 +73,7 @@ Accept wildcard characters: False
 ```
 
 ### -DatasourceId
-Specifies the ID of the datasource.
+Specifies the ID of the datasource associated with the instance group.
 This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter sets.
 
 ```yaml
@@ -91,9 +89,9 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Specifies the ID of the device.
+Specifies the ID of the device associated with the instance group.
 This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets.
-It can also be specified using the 'DeviceId' alias.
+This parameter can also be specified using the 'DeviceId' alias.
 
 ```yaml
 Type: Int32
@@ -108,9 +106,9 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Specifies the name of the device.
+Specifies the name of the device associated with the instance group.
 This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets.
-It can also be specified using the 'DeviceName' alias.
+This parameter can also be specified using the 'DeviceName' alias.
 
 ```yaml
 Type: String
@@ -124,8 +122,8 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InstanceName
-Specifies the name of the datasource instance.
+### -InstanceGroupName
+Specifies the name of the instance group to be removed.
 This parameter is mandatory.
 
 ```yaml
@@ -140,16 +138,31 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DataPointName
-Specifies the name of the data point.
-This parameter is mandatory.
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
 
 ```yaml
-Type: String
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: wi
 
-Required: True
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -176,6 +189,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
+### None. You cannot pipe objects to this function.
 ## OUTPUTS
 
 ## NOTES

--- a/Documentation/Set-LMAccessGroup.md
+++ b/Documentation/Set-LMAccessGroup.md
@@ -5,28 +5,22 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-LMDatasourceUpdateHistory
+# Set-LMAccessGroup
 
 ## SYNOPSIS
 {{ Fill in the Synopsis }}
 
 ## SYNTAX
 
-### Id (Default)
+### Id
 ```
-Get-LMDatasourceUpdateHistory -Id <Int32> [-Filter <Object>] [-BatchSize <Int32>]
+Set-LMAccessGroup [-Id <Int32>] [-NewName <String>] [-Description <String>] [-Tenant <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### Name
 ```
-Get-LMDatasourceUpdateHistory [-Name <String>] [-Filter <Object>] [-BatchSize <Int32>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
-```
-
-### DisplayName
-```
-Get-LMDatasourceUpdateHistory [-DisplayName <String>] [-Filter <Object>] [-BatchSize <Int32>]
+Set-LMAccessGroup [-Name <String>] [-NewName <String>] [-Description <String>] [-Tenant <String>]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -44,6 +38,21 @@ PS C:\> {{ Add example code here }}
 
 ## PARAMETERS
 
+### -Description
+{{ Fill Description Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Id
 {{ Fill Id Description }}
 
@@ -52,10 +61,10 @@ Type: Int32
 Parameter Sets: Id
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -74,26 +83,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DisplayName
-{{ Fill DisplayName Description }}
+### -NewName
+{{ Fill NewName Description }}
 
 ```yaml
 Type: String
-Parameter Sets: DisplayName
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Filter
-{{ Fill Filter Description }}
-
-```yaml
-Type: Object
 Parameter Sets: (All)
 Aliases:
 
@@ -104,11 +98,11 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BatchSize
-{{ Fill BatchSize Description }}
+### -Tenant
+{{ Fill Tenant Description }}
 
 ```yaml
-Type: Int32
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -139,7 +133,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### None
+### System.Int32
 ## OUTPUTS
 
 ### System.Object

--- a/Documentation/Set-LMAccessGroup.md
+++ b/Documentation/Set-LMAccessGroup.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Set-LMAccessGroup
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Sets the properties of a LogicMonitor access group.
 
 ## SYNTAX
 
@@ -25,36 +25,29 @@ Set-LMAccessGroup [-Name <String>] [-NewName <String>] [-Description <String>] [
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Set-LMAccessGroup function is used to set the properties of a LogicMonitor access group.
+It allows you to specify the access group either by its ID or by its name.
+You can set the new name, description, and tenant ID for the access group.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Set-LMAccessGroup -Id 123 -NewName "New Access Group" -Description "This is a new access group" -Tenant "abc123"
+Sets the properties of the access group with ID 123. The new name is set to "New Access Group", the description is set to "This is a new access group", and the tenant ID is set to "abc123".
 ```
 
-{{ Add example description here }}
+### EXAMPLE 2
+```
+Set-LMAccessGroup -Name "Old Access Group" -NewName "New Access Group" -Description "This is a new access group" -Tenant "abc123"
+Sets the properties of the access group with name "Old Access Group". The new name is set to "New Access Group", the description is set to "This is a new access group", and the tenant ID is set to "abc123".
+```
 
 ## PARAMETERS
 
-### -Description
-{{ Fill Description Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Id
-{{ Fill Id Description }}
+Specifies the ID of the access group.
+This parameter is used when you want to set the properties of the access group by its ID.
 
 ```yaml
 Type: Int32
@@ -63,13 +56,14 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: 0
 Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
 ### -Name
-{{ Fill Name Description }}
+Specifies the name of the access group.
+This parameter is used when you want to set the properties of the access group by its name.
 
 ```yaml
 Type: String
@@ -84,7 +78,22 @@ Accept wildcard characters: False
 ```
 
 ### -NewName
-{{ Fill NewName Description }}
+Specifies the new name for the access group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Specifies the new description for the access group.
 
 ```yaml
 Type: String
@@ -99,7 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -Tenant
-{{ Fill Tenant Description }}
+Specifies the tenant ID for the access group.
 
 ```yaml
 Type: String
@@ -133,10 +142,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.Int32
 ## OUTPUTS
 
-### System.Object
 ## NOTES
+This function requires you to be logged in and have valid API credentials.
+Use the Connect-LMAccount function to log in before running this command.
 
 ## RELATED LINKS

--- a/Documentation/Set-LMDevice.md
+++ b/Documentation/Set-LMDevice.md
@@ -15,21 +15,21 @@ schema: 2.0.0
 ### Id
 ```
 Set-LMDevice -Id <String> [-NewName <String>] [-DisplayName <String>] [-Description <String>]
- [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-Properties <Hashtable>]
- [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>] [-DisableAlerting <Boolean>]
- [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>] [-NetflowCollectorId <Int32>]
- [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-AutoBalancedCollectorGroupId <Int32>]
+ [-Properties <Hashtable>] [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>]
+ [-DisableAlerting <Boolean>] [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>]
+ [-NetflowCollectorId <Int32>] [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Name
 ```
 Set-LMDevice -Name <String> [-NewName <String>] [-DisplayName <String>] [-Description <String>]
- [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-Properties <Hashtable>]
- [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>] [-DisableAlerting <Boolean>]
- [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>] [-NetflowCollectorId <Int32>]
- [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>] [-ProgressAction <ActionPreference>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-PreferredCollectorId <Int32>] [-PreferredCollectorGroupId <Int32>] [-AutoBalancedCollectorGroupId <Int32>]
+ [-Properties <Hashtable>] [-HostGroupIds <String[]>] [-PropertiesMethod <String>] [-Link <String>]
+ [-DisableAlerting <Boolean>] [-EnableNetFlow <Boolean>] [-NetflowCollectorGroupId <Int32>]
+ [-NetflowCollectorId <Int32>] [-LogCollectorGroupId <Int32>] [-LogCollectorId <Int32>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,6 +45,21 @@ PS C:\> {{ Add example code here }}
 {{ Add example description here }}
 
 ## PARAMETERS
+
+### -AutoBalancedCollectorGroupId
+{{ Fill AutoBalancedCollectorGroupId Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.

--- a/Documentation/Set-LMDeviceDatasourceInstance.md
+++ b/Documentation/Set-LMDeviceDatasourceInstance.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Set-LMDeviceDatasourceInstance
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Sets the properties of a LogicMonitor device datasource instance.
 
 ## SYNTAX
 
@@ -16,7 +16,7 @@ schema: 2.0.0
 ```
 Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-WildValue2 <String>]
  [-Description <String>] [-Properties <Hashtable>] [-StopMonitoring <Boolean>] [-DisableAlerting <Boolean>]
- [-InstanceGroupId <String>] -InstanceId <String> -DatasourceName <String> -DeviceName <String>
+ [-InstanceGroupId <String>] -InstanceId <String> -DatasourceName <String> -Name <String>
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -24,7 +24,7 @@ Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-W
 ```
 Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-WildValue2 <String>]
  [-Description <String>] [-Properties <Hashtable>] [-StopMonitoring <Boolean>] [-DisableAlerting <Boolean>]
- [-InstanceGroupId <String>] -InstanceId <String> -DatasourceName <String> -DeviceId <String>
+ [-InstanceGroupId <String>] -InstanceId <String> -DatasourceName <String> -Id <String>
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -32,7 +32,7 @@ Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-W
 ```
 Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-WildValue2 <String>]
  [-Description <String>] [-Properties <Hashtable>] [-StopMonitoring <Boolean>] [-DisableAlerting <Boolean>]
- [-InstanceGroupId <String>] -InstanceId <String> -DatasourceId <String> -DeviceName <String>
+ [-InstanceGroupId <String>] -InstanceId <String> -DatasourceId <String> -Name <String>
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -40,31 +40,39 @@ Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-W
 ```
 Set-LMDeviceDatasourceInstance [-DisplayName <String>] [-WildValue <String>] [-WildValue2 <String>]
  [-Description <String>] [-Properties <Hashtable>] [-StopMonitoring <Boolean>] [-DisableAlerting <Boolean>]
- [-InstanceGroupId <String>] -InstanceId <String> -DatasourceId <String> -DeviceId <String>
+ [-InstanceGroupId <String>] -InstanceId <String> -DatasourceId <String> -Id <String>
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+The Set-LMDeviceDatasourceInstance function is used to set the properties of a LogicMonitor device datasource instance.
+It allows you to update the display name, wild values, description, custom properties, monitoring and alerting settings, and instance group ID of the specified instance.
 
 ## EXAMPLES
 
-### Example 1
-```powershell
-PS C:\> {{ Add example code here }}
+### EXAMPLE 1
+```
+Set-LMDeviceDatasourceInstance -InstanceId 12345 -DisplayName "New Instance Name" -Description "Updated instance description"
 ```
 
-{{ Add example description here }}
+This example sets the display name and description of the instance with ID 12345.
+
+### EXAMPLE 2
+```
+Get-LMDevice -Name "MyDevice" | Set-LMDeviceDatasourceInstance -DatasourceName "MyDatasource" -DisplayName "New Instance Name"
+```
+
+This example retrieves the device with the name "MyDevice" and sets the display name of the instance associated with the datasource "MyDatasource".
 
 ## PARAMETERS
 
-### -Confirm
-Prompts you for confirmation before running the cmdlet.
+### -DisplayName
+Specifies the new display name for the instance.
 
 ```yaml
-Type: SwitchParameter
+Type: String
 Parameter Sets: (All)
-Aliases: cf
+Aliases:
 
 Required: False
 Position: Named
@@ -73,8 +81,148 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -WildValue
+Specifies the first wild value for the instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WildValue2
+Specifies the second wild value for the instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Specifies the description for the instance.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Properties
+Specifies a hashtable of custom properties for the instance.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StopMonitoring
+Specifies whether to stop monitoring the instance.
+This parameter accepts $true or $false.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableAlerting
+Specifies whether to disable alerting for the instance.
+This parameter accepts $true or $false.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InstanceGroupId
+Specifies the ID of the instance group to which the instance belongs.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InstanceId
+Specifies the ID of the instance to update.
+This parameter is mandatory and can be provided via pipeline.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -DatasourceName
+Specifies the name of the datasource associated with the instance.
+This parameter is mandatory when using the 'Name-dsName' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Name-dsName, Id-dsName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DatasourceId
-{{ Fill DatasourceId Description }}
+Specifies the ID of the datasource associated with the instance.
+This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter set.
 
 ```yaml
 Type: String
@@ -100,43 +248,15 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DatasourceName
-{{ Fill DatasourceName Description }}
-
-```yaml
-Type: String
-Parameter Sets: Name-dsName, Id-dsName
-Aliases:
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Description
-{{ Fill Description Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DeviceId
-{{ Fill DeviceId Description }}
+### -Id
+Specifies the ID of the device associated with the instance.
+This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter set.
+This parameter can also be specified using the 'DeviceId' alias.
 
 ```yaml
 Type: String
 Parameter Sets: Id-dsName
-Aliases:
+Aliases: DeviceId
 
 Required: True
 Position: Named
@@ -148,7 +268,7 @@ Accept wildcard characters: False
 ```yaml
 Type: String
 Parameter Sets: Id-dsId
-Aliases:
+Aliases: DeviceId
 
 Required: True
 Position: Named
@@ -157,105 +277,17 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DeviceName
-{{ Fill DeviceName Description }}
+### -Name
+Specifies the name of the device associated with the instance.
+This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter set.
+This parameter can also be specified using the 'DeviceName' alias.
 
 ```yaml
 Type: String
 Parameter Sets: Name-dsName, Name-dsId
-Aliases:
+Aliases: DeviceName
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisableAlerting
-{{ Fill DisableAlerting Description }}
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -DisplayName
-{{ Fill DisplayName Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InstanceGroupId
-{{ Fill InstanceGroupId Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InstanceId
-{{ Fill InstanceId Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: Id
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
-
-### -Properties
-{{ Fill Properties Description }}
-
-```yaml
-Type: Hashtable
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -StopMonitoring
-{{ Fill StopMonitoring Description }}
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -278,28 +310,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WildValue
-{{ Fill WildValue Description }}
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
 
 ```yaml
-Type: String
+Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -WildValue2
-{{ Fill WildValue2 Description }}
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
+Aliases: cf
 
 Required: False
 Position: Named
@@ -328,10 +345,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String
 ## OUTPUTS
 
-### System.Object
 ## NOTES
 
 ## RELATED LINKS

--- a/Documentation/Set-LMUserdata.md
+++ b/Documentation/Set-LMUserdata.md
@@ -1,0 +1,156 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Set-LMUserdata
+
+## SYNOPSIS
+Sets userdata for a LogicMonitor user.
+Currently only setting the default dashboard is supported.
+
+## SYNTAX
+
+### Id (Default)
+```
+Set-LMUserdata -Id <String> -DashboardId <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Name
+```
+Set-LMUserdata -Name <String> -DashboardId <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-LMUserdata function is used to set the user data for a LogicMonitor user.
+It allows you to specify the user by either their Id or Name, and the dashboard Id for which the user data should be set.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-LMUserdata -Id "12345" -DashboardId "67890"
+Sets the user data for the user with Id "12345" for the dashboard with Id "67890".
+```
+
+### EXAMPLE 2
+```
+Set-LMUserdata -Name "JohnDoe" -DashboardId "67890"
+Sets the user data for the user with Name "JohnDoe" for the dashboard with Id "67890".
+```
+
+## PARAMETERS
+
+### -Id
+Specifies the Id of the user.
+This parameter is mandatory when using the 'Id' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Id
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the Name of the user.
+This parameter is mandatory when using the 'Name' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Name
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DashboardId
+Specifies the Id of the dashboard for which the user data should be set.
+This parameter is mandatory.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None.
+## OUTPUTS
+
+### System.Object
+### Returns the response from the LogicMonitor API.
+## NOTES
+This function requires a valid API authentication.
+Make sure you are logged in before running any commands using Connect-LMAccount.
+
+## RELATED LINKS

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -192,7 +192,7 @@ Set-LMDevice -Name "192.168.1.1" -DisplayName $deviceProperty
 #Method Three
 #Using Get-LMDeviceGroupDevices to retrieve a list of devices and loop through each and set the sysname value to the displayname
 $devices = Get-LMDeviceGroupDevices -Name "Cambium Wireless"
-foreach ($dev in $devices) {
+Foreach ($dev in $devices) {
     $deviceProperty = ($dev.systemProperties[$dev.systemProperties.name.IndexOf("system.sysname")].value)
     if($deviceProperty -and $dev.systemProperties.name.IndexOf("system.sysname") -ne -1){
         Set-LMDevice -Id $dev.id -DisplayName $deviceProperty
@@ -209,7 +209,7 @@ $processedDeviceList = @()
 $devices = Get-LMDeviceGroupDevices -Id "23"
 
 #Loop through each device and check for presence of property
-foreach ($dev in $devices) {
+Foreach ($dev in $devices) {
     $propName = "test.prop"
     $propValue = "1234"
     $currentPropValue = ($dev.customProperties[$dev.customProperties.name.IndexOf($propName)].value)

--- a/Logic.Monitor.Format.ps1xml
+++ b/Logic.Monitor.Format.ps1xml
@@ -54,6 +54,47 @@
             </TableRowEntries>
          </TableControl>
       </View>
+      <!-- New View LogicMonitor.AccessGroup-->
+      <View>
+         <Name>LogicMonitorAccessGroup</Name>
+         <ViewSelectedBy>
+            <TypeName>LogicMonitor.AccessGroup</TypeName>
+         </ViewSelectedBy>
+         <TableControl>
+            <TableHeaders>
+               <TableColumnHeader>
+                  <Label>id</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>name</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>tenantid</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>description</Label>
+               </TableColumnHeader>
+            </TableHeaders>
+            <TableRowEntries>
+               <TableRowEntry>
+                  <TableColumnItems>
+                     <TableColumnItem>
+                        <PropertyName>id</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>name</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>tenantid</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>description</PropertyName>
+                     </TableColumnItem>
+                  </TableColumnItems>
+               </TableRowEntry>
+            </TableRowEntries>
+         </TableControl>
+      </View>
       <!-- New View LogicMonitor.TopologyMap-->
       <View>
          <Name>LogicMonitorTopologyMap</Name>

--- a/Logic.Monitor.psd1
+++ b/Logic.Monitor.psd1
@@ -51,7 +51,7 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules    = @('Microsoft.PowerShell.SecretManagement','Microsoft.PowerShell.SecretStore')
+    RequiredModules    = @('Microsoft.PowerShell.SecretManagement', 'Microsoft.PowerShell.SecretStore')
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies = @()

--- a/Private/Add-ObjectTypeInfo.ps1
+++ b/Private/Add-ObjectTypeInfo.ps1
@@ -96,7 +96,7 @@ function Add-ObjectTypeInfo {
         http://blogs.microsoft.co.il/scriptfanatic/2012/04/13/custom-objects-default-display-in-powershell-30/
     #>
     [CmdletBinding()] 
-    param(
+    Param (
         [Parameter( Mandatory = $true,
             Position = 0,
             ValueFromPipeline = $true )]
@@ -121,17 +121,17 @@ function Add-ObjectTypeInfo {
     )
     
     Begin {
-        if ($PSBoundParameters.ContainsKey('DefaultProperties')) {
+        If ($PSBoundParameters.ContainsKey('DefaultProperties')) {
             # define a subset of properties
             $ddps = New-Object System.Management.Automation.PSPropertySet DefaultDisplayPropertySet, $DefaultProperties
             $PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]$ddps
         }
     }
     Process {
-        foreach ($Object in $InputObject) {
+        Foreach ($Object in $InputObject) {
             switch ($PSBoundParameters.Keys) {
                 'PropertyToAdd' {
-                    foreach ($Key in $PropertyToAdd.Keys) {
+                    Foreach ($Key in $PropertyToAdd.Keys) {
                         #Add some noteproperties. Slightly faster than Add-Member.
                         $Object.PSObject.Properties.Add( ( New-Object PSNoteProperty($Key, $PropertyToAdd[$Key]) ) )  
                     }
@@ -145,7 +145,7 @@ function Add-ObjectTypeInfo {
                     Add-Member -InputObject $Object -MemberType MemberSet -Name PSStandardMembers -Value $PSStandardMembers
                 }
             }
-            if ($Passthru) {
+            If ($Passthru) {
                 $Object
             }
         }

--- a/Private/Format-LMFilter-v1.ps1
+++ b/Private/Format-LMFilter-v1.ps1
@@ -24,7 +24,7 @@
     System.String. The function returns a string that represents the formatted filter.
 
 .NOTES
-    The function does not throw any errors. If a property in the Filter parameter is not in the PropList parameter, it is simply removed from the filter.
+    If a property in the Filter parameter is not in the PropList parameter, it is simply removed from the filter.
 #>
 Function Format-LMFilter-v1 {
     [CmdletBinding()]
@@ -48,7 +48,7 @@ Function Format-LMFilter-v1 {
     }
 
     #Create filter string from hash table and url encode
-    foreach ($Key in $($Filter.keys)) {
+    Foreach ($Key in $($Filter.keys)) {
         $FilterString += $Key + ":" + "`"$($Filter[$Key])`"" + ","
     }
     $FilterString = $FilterString.trimend(',')

--- a/Private/Format-LMFilter.ps1
+++ b/Private/Format-LMFilter.ps1
@@ -35,49 +35,49 @@ Function Format-LMFilter {
     Param (
         [Object]$Filter,
 
-        [String[]]$PropList = @("name","id","status","severity","startEpoch","endEpoch","cleared","resourceTemplateName","monitorObjectName","customProperties","systemProperties","autoProperties","displayName")
+        [String[]]$PropList = @("name", "id", "status", "severity", "startEpoch", "endEpoch", "cleared", "resourceTemplateName", "monitorObjectName", "customProperties", "systemProperties", "autoProperties", "displayName")
     )
     $FormatedFilter = ""
     #Keep legacy filter method for backwards compatability
-    If($Filter -is [hashtable]){
+    If ($Filter -is [hashtable]) {
         $FormatedFilter = Format-LMFilter-v1 -Filter $Filter -PropList $PropList
         Write-Debug "Constructed Filter-v1: $FormatedFilter"
         Return $FormatedFilter
     }
-    Else{    
+    Else {    
         #Split our filters in an array based on logical operator
-        $FilterArray = [regex]::Split($Filter,'(\s+-and\s+|\s+-or\s+)')
+        $FilterArray = [regex]::Split($Filter, '(\s+-and\s+|\s+-or\s+)')
     
-        Foreach ($Filter in $FilterArray){
-            If($Filter -match '\s+-and\s+'){
+        Foreach ($Filter in $FilterArray) {
+            If ($Filter -match '\s+-and\s+') {
                 $FormatedFilter += ","
             }
-            ElseIf($Filter -match '\s+-or\s+'){
+            ElseIf ($Filter -match '\s+-or\s+') {
                 $FormatedFilter += "||"
             }
-            Else{
-                $SingleFilterArray = [regex]::Split($Filter,'(\s+-eq\s+|\s+-ne\s+|\s+-gt\s+|\s+-lt\s+|\s+-ge\s+|\s+-le\s+|\s+-contains\s+|\s+-notcontains\s+)')
-                If(($SingleFilterArray | Measure-Object).Count -gt 1){
-                    Foreach($SingleFilter in $SingleFilterArray){
-                        If($SingleFilter -match '(\s+-eq\s+|\s+-ne\s+|\s+-gt\s+|\s+-lt\s+|\s+-ge\s+|\s+-le\s+|\s+-contains\s+|\s+-notcontains\s+)'){
-                            Switch -Regex ($SingleFilter){
-                                '\s+-eq\s+' { $FormatedFilter += ":"}
-                                '\s+-ne\s+' { $FormatedFilter += "!:"}
-                                '\s+-gt\s+' { $FormatedFilter += ">"}
-                                '\s+-lt\s+' { $FormatedFilter += "<"}
-                                '\s+-ge\s+' { $FormatedFilter += ">:"}
-                                '\s+-le\s+' { $FormatedFilter += "<:"}
-                                '\s+-contains\s+' { $FormatedFilter += "~"}
-                                '\s+-notcontains\s+' { $FormatedFilter += "!~"}
-                                default {Write-LMHost "[ERROR]: Invalid filter syntax: $Filter" -ForegroundColor Red}
+            Else {
+                $SingleFilterArray = [regex]::Split($Filter, '(\s+-eq\s+|\s+-ne\s+|\s+-gt\s+|\s+-lt\s+|\s+-ge\s+|\s+-le\s+|\s+-contains\s+|\s+-notcontains\s+)')
+                If (($SingleFilterArray | Measure-Object).Count -gt 1) {
+                    Foreach ($SingleFilter in $SingleFilterArray) {
+                        If ($SingleFilter -match '(\s+-eq\s+|\s+-ne\s+|\s+-gt\s+|\s+-lt\s+|\s+-ge\s+|\s+-le\s+|\s+-contains\s+|\s+-notcontains\s+)') {
+                            Switch -Regex ($SingleFilter) {
+                                '\s+-eq\s+' { $FormatedFilter += ":" }
+                                '\s+-ne\s+' { $FormatedFilter += "!:" }
+                                '\s+-gt\s+' { $FormatedFilter += ">" }
+                                '\s+-lt\s+' { $FormatedFilter += "<" }
+                                '\s+-ge\s+' { $FormatedFilter += ">:" }
+                                '\s+-le\s+' { $FormatedFilter += "<:" }
+                                '\s+-contains\s+' { $FormatedFilter += "~" }
+                                '\s+-notcontains\s+' { $FormatedFilter += "!~" }
+                                default { Write-LMHost "[ERROR]: Invalid filter syntax: $Filter" -ForegroundColor Red }
                             }
                         }
-                        Else{
-                            $FormatedFilter += $SingleFilter.Replace("'","`"") #replace single quotes with double quotes as reqired by LM API
+                        Else {
+                            $FormatedFilter += $SingleFilter.Replace("'", "`"") #replace single quotes with double quotes as reqired by LM API
                         }
                     }
                 }
-                Else{
+                Else {
                     Write-LMHost "[ERROR]: Invalid filter syntax: $SingleFilterArray" -ForegroundColor Red
                 }
             }

--- a/Private/Format-LMFilter.ps1
+++ b/Private/Format-LMFilter.ps1
@@ -52,7 +52,7 @@ Function Format-LMFilter {
             If ($Filter -match '\s+-and\s+') {
                 $FormatedFilter += ","
             }
-            ElseIf ($Filter -match '\s+-or\s+') {
+            Elseif ($Filter -match '\s+-or\s+') {
                 $FormatedFilter += "||"
             }
             Else {

--- a/Private/New-LMHeader.ps1
+++ b/Private/New-LMHeader.ps1
@@ -62,24 +62,24 @@ Function New-LMHeader {
     $Header = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
     $Session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-    If($Auth.Type -eq "Bearer"){
+    If ($Auth.Type -eq "Bearer") {
         $Token = [System.Net.NetworkCredential]::new("", $Auth.BearerToken).Password
         $Header.Add("Authorization", "Bearer $Token")
     }
-    ElseIf($Auth.Type -eq "SessionSync"){
+    ElseIf ($Auth.Type -eq "SessionSync") {
         $SessionInfo = Get-LMSession -AccountName $Auth.Portal
-        If($SessionInfo){
+        If ($SessionInfo) {
             $Header.Add("Cookie", "JSESSIONID=$($SessionInfo.jSessionID)")
             $Session.Cookies.Add((New-Object System.Net.Cookie("JSESSIONID", $SessionInfo.jSessionID, "/", $SessionInfo.domain)))
             $Header.Add("X-CSRF-Token", "$($SessionInfo.token)")
         }
-        Else{
+        Else {
             throw "Unable to generate header details, ensure you are connected to a portal and try again."
         }
     }
-    Else{
+    Else {
         # Get current time in milliseconds...
-        $Epoch = [Math]::Round((New-TimeSpan -start (Get-Date -Date "1/1/1970") -end (Get-Date).ToUniversalTime()).TotalMilliseconds)
+        $Epoch = [Math]::Round((New-TimeSpan -Start (Get-Date -Date "1/1/1970") -End (Get-Date).ToUniversalTime()).TotalMilliseconds)
 
         # Concatenate general request details...
         If ($Method -eq "GET" -or $Method -eq "DELETE") {
@@ -105,5 +105,5 @@ Function New-LMHeader {
     $Header.Add("Content-Type", $ContentType)
     $Header.Add("X-Version", $Version)
 
-    Return @($Header,$Session)
+    Return @($Header, $Session)
 }

--- a/Private/New-LMHeader.ps1
+++ b/Private/New-LMHeader.ps1
@@ -66,7 +66,7 @@ Function New-LMHeader {
         $Token = [System.Net.NetworkCredential]::new("", $Auth.BearerToken).Password
         $Header.Add("Authorization", "Bearer $Token")
     }
-    ElseIf ($Auth.Type -eq "SessionSync") {
+    Elseif ($Auth.Type -eq "SessionSync") {
         $SessionInfo = Get-LMSession -AccountName $Auth.Portal
         If ($SessionInfo) {
             $Header.Add("Cookie", "JSESSIONID=$($SessionInfo.jSessionID)")
@@ -74,7 +74,7 @@ Function New-LMHeader {
             $Header.Add("X-CSRF-Token", "$($SessionInfo.token)")
         }
         Else {
-            throw "Unable to generate header details, ensure you are connected to a portal and try again."
+            Throw "Unable to generate header details, ensure you are connected to a portal and try again."
         }
     }
     Else {

--- a/Private/New-LMRandomCred.ps1
+++ b/Private/New-LMRandomCred.ps1
@@ -37,7 +37,7 @@ Function New-LMRandomCred {
   
     #Construct randomized password
     For ($i = 0 ; $i -lt $Length ; $i++) {
-        $Result[$i] = $SymbolSet[$Bytes[$i]%$SymbolSet.Length]
+        $Result[$i] = $SymbolSet[$Bytes[$i] % $SymbolSet.Length]
     }
  
     #Return result

--- a/Private/Resolve-LMDebugInfo.ps1
+++ b/Private/Resolve-LMDebugInfo.ps1
@@ -34,5 +34,5 @@ Function Resolve-LMDebugInfo {
     Write-Debug "Bound Parameters: $($Command.BoundParameters.GetEnumerator() | ForEach-Object {"[" + $($_.Key) + ":" + $($_.Value) + "]"})"
     Write-Debug "Invoked URL: $Url"
     If ($Payload) { Write-Debug "Request Payload: `n$Payload" }
-    Write-Debug "Request Headers: $($Headers.GetEnumerator() | ForEach-Object {"[" + $($_.Key) + ":" + $(if ($_.Value.length -gt 25) { $_.Value.substring(0, 25) + "...]" } else { $($_.Value) + "]" })})"
+    Write-Debug "Request Headers: $($Headers.GetEnumerator() | ForEach-Object {"[" + $($_.Key) + ":" + $(If ($_.Value.length -gt 25) { $_.Value.substring(0, 25) + "...]" } Else { $($_.Value) + "]" })})"
 }

--- a/Private/Resolve-LMDebugInfo.ps1
+++ b/Private/Resolve-LMDebugInfo.ps1
@@ -33,6 +33,6 @@ Function Resolve-LMDebugInfo {
     Write-Debug "Invoked Command: $($Command.MyCommand)"
     Write-Debug "Bound Parameters: $($Command.BoundParameters.GetEnumerator() | ForEach-Object {"[" + $($_.Key) + ":" + $($_.Value) + "]"})"
     Write-Debug "Invoked URL: $Url"
-    If($Payload){Write-Debug "Request Payload: `n$Payload"}
+    If ($Payload) { Write-Debug "Request Payload: `n$Payload" }
     Write-Debug "Request Headers: $($Headers.GetEnumerator() | ForEach-Object {"[" + $($_.Key) + ":" + $(if ($_.Value.length -gt 25) { $_.Value.substring(0, 25) + "...]" } else { $($_.Value) + "]" })})"
 }

--- a/Private/Resolve-LMException.ps1
+++ b/Private/Resolve-LMException.ps1
@@ -48,7 +48,6 @@ Function Resolve-LMException {
                     [Console]::ForegroundColor = 'red'
                     [Console]::Error.WriteLine("Failed to execute web request($($HttpStatusCode)): $HttpException")
                     [Console]::ResetColor()
-                    #throw "Failed to execute web request($($HttpStatusCode)): $HttpException"
                 }
             }
             default {
@@ -62,7 +61,6 @@ Function Resolve-LMException {
                     [Console]::ForegroundColor = 'red'
                     [Console]::Error.WriteLine("Failed to execute web request: $LMError")
                     [Console]::ResetColor()
-                    #throw "Failed to execute web request: $LMError"
                 }
             }
         }

--- a/Private/Resolve-LMException.ps1
+++ b/Private/Resolve-LMException.ps1
@@ -29,13 +29,13 @@ Function Resolve-LMException {
     ELse {
         Switch ($LMException.Exception.GetType().FullName) {
             { "System.Net.WebException" -or "Microsoft.PowerShell.Commands.HttpResponseException" } {
-                Try{
+                Try {
                     $HttpException = ($LMException.ErrorDetails.Message | ConvertFrom-Json -ErrorAction SilentlyContinue).errorMessage
                     If (!$HttpException) {
                         $HttpException = ($LMException.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop).message
                     }
                 }
-                Catch{
+                Catch {
                     $HttpException = $LMException.ErrorDetails.Message
                 }
                 $HttpStatusCode = $LMException.Exception.Response.StatusCode.value__
@@ -44,7 +44,7 @@ Function Resolve-LMException {
                 #Write to $Error object but suppress so stack trace is not displayed
                 Write-Error "Failed to execute web request($($HttpStatusCode)): $HttpException" -ErrorAction SilentlyContinue
                 #Pretty print error to console
-                If($ErrorActionPreference -ne "SilentlyContinue"){
+                If ($ErrorActionPreference -ne "SilentlyContinue") {
                     [Console]::ForegroundColor = 'red'
                     [Console]::Error.WriteLine("Failed to execute web request($($HttpStatusCode)): $HttpException")
                     [Console]::ResetColor()
@@ -58,7 +58,7 @@ Function Resolve-LMException {
                 #Write to $Error object but suppress so stack trace is not displayed
                 Write-Error "Failed to execute web request: $LMError" -ErrorAction SilentlyContinue
                 #Pretty print error to console
-                If($ErrorActionPreference -ne "SilentlyContinue"){
+                If ($ErrorActionPreference -ne "SilentlyContinue") {
                     [Console]::ForegroundColor = 'red'
                     [Console]::Error.WriteLine("Failed to execute web request: $LMError")
                     [Console]::ResetColor()

--- a/Private/Test-LookupResult.ps1
+++ b/Private/Test-LookupResult.ps1
@@ -29,7 +29,7 @@ Function Test-LookupResult {
         return $true
     }
     #If empty stop processing since we have no Id to use
-    ElseIf (!$Result) {
+    Elseif (!$Result) {
         [Console]::ForegroundColor = 'red'
         [Console]::Error.WriteLine("Unable to find resource for the specified name value: $LookupString. Please check spelling and try again.")
         [Console]::ResetColor()

--- a/Private/Update-LogicMonitorModule.ps1
+++ b/Private/Update-LogicMonitorModule.ps1
@@ -33,12 +33,12 @@
 
 Function Update-LogicMonitorModule {
     Param (
-        [String[]]$Modules = @('Logic.Monitor','Logic.Monitor.SE'),
+        [String[]]$Modules = @('Logic.Monitor', 'Logic.Monitor.SE'),
         [Boolean]$UninstallFirst = $False,
         [Switch]$CheckOnly
     )
 
-    Foreach($Module in $Modules){
+    Foreach ($Module in $Modules) {
         # Read the currently installed version
         $Installed = Get-Module -ListAvailable -Name $Module
     
@@ -46,10 +46,10 @@ Function Update-LogicMonitorModule {
         If ($Installed -is [Array]) {
             $InstalledVersion = $Installed[0].Version
         }
-        ElseIf($Installed.Version) {
+        ElseIf ($Installed.Version) {
             $InstalledVersion = $Installed.Version
         }
-        Else{
+        Else {
             #Not installed or manually imported
             return
         }
@@ -62,7 +62,7 @@ Function Update-LogicMonitorModule {
         If ([System.Version]$OnlineVersion -gt [System.Version]$InstalledVersion) {
             
             # Uninstall the old version
-            If($CheckOnly){
+            If ($CheckOnly) {
                 Write-LMHost "[INFO]: You are currently using an outdated version ($InstalledVersion) of $Module, please consider upgrading to the latest version ($OnlineVersion) as soon as possible. Use the -AutoUpdateModule switch next time you connect to auto upgrade to the latest version." -ForegroundColor Yellow
             }
             ElseIf ($UninstallFirst -eq $true) {
@@ -73,7 +73,7 @@ Function Update-LogicMonitorModule {
                 Install-Module -Name $Module -Force -AllowClobber -Verbose:$False -MinimumVersion $OnlineVersion
                 Update-LogicMonitorModule -CheckOnly -Modules @($Module)
             }
-            Else{
+            Else {
                 Write-LMHost "[INFO]: You are currently using an outdated version ($InstalledVersion) of $Module. Installing newer Module $Module version $OnlineVersion." -ForegroundColor Yellow
                 Install-Module -Name $Module -Force -AllowClobber -Verbose:$False -MinimumVersion $OnlineVersion
                 Update-LogicMonitorModule -CheckOnly -Modules @($Module)

--- a/Private/Update-LogicMonitorModule.ps1
+++ b/Private/Update-LogicMonitorModule.ps1
@@ -46,7 +46,7 @@ Function Update-LogicMonitorModule {
         If ($Installed -is [Array]) {
             $InstalledVersion = $Installed[0].Version
         }
-        ElseIf ($Installed.Version) {
+        Elseif ($Installed.Version) {
             $InstalledVersion = $Installed.Version
         }
         Else {
@@ -65,7 +65,7 @@ Function Update-LogicMonitorModule {
             If ($CheckOnly) {
                 Write-LMHost "[INFO]: You are currently using an outdated version ($InstalledVersion) of $Module, please consider upgrading to the latest version ($OnlineVersion) as soon as possible. Use the -AutoUpdateModule switch next time you connect to auto upgrade to the latest version." -ForegroundColor Yellow
             }
-            ElseIf ($UninstallFirst -eq $true) {
+            Elseif ($UninstallFirst -eq $true) {
                 Write-LMHost "[INFO]: You are currently using an outdated version ($InstalledVersion) of $Module, uninstalling prior Module $Module version $InstalledVersion" -ForegroundColor Yellow
                 Uninstall-Module -Name $Module -Force -Verbose:$False
     

--- a/Private/Write-LMHost.ps1
+++ b/Private/Write-LMHost.ps1
@@ -29,28 +29,28 @@ Writes the error message "Error: Something went wrong." to the host console with
 
 Function Write-LMHost {
     Param (
-        [Object]$Message=$args[0],
+        [Object]$Message = $args[0],
     
         [Nullable[ConsoleColor]]$ForegroundColor,
 
         [Nullable[ConsoleColor]]$BackgroundColor
     )
     #Only log message content if switch is set to true during connect lm account
-    If($Script:LMAuth.Logging){
-        If($ForegroundColor -and !$BackgroundColor){
+    If ($Script:LMAuth.Logging) {
+        If ($ForegroundColor -and !$BackgroundColor) {
             Write-Host $Message -ForegroundColor $ForegroundColor
         }
-        ElseIf(!$ForegroundColor -and $BackgroundColor) {
+        ElseIf (!$ForegroundColor -and $BackgroundColor) {
             Write-Host $Message -BackgroundColor $BackgroundColor
         }
-        ElseIf($ForegroundColor -and $BackgroundColor){
+        ElseIf ($ForegroundColor -and $BackgroundColor) {
             Write-Host $Message -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
         }
-        Else{
+        Else {
             Write-Host $Message
         }
     }
-    Else{
+    Else {
         Write-Host $Message
     }
 }

--- a/Private/Write-LMHost.ps1
+++ b/Private/Write-LMHost.ps1
@@ -40,10 +40,10 @@ Function Write-LMHost {
         If ($ForegroundColor -and !$BackgroundColor) {
             Write-Host $Message -ForegroundColor $ForegroundColor
         }
-        ElseIf (!$ForegroundColor -and $BackgroundColor) {
+        Elseif (!$ForegroundColor -and $BackgroundColor) {
             Write-Host $Message -BackgroundColor $BackgroundColor
         }
-        ElseIf ($ForegroundColor -and $BackgroundColor) {
+        Elseif ($ForegroundColor -and $BackgroundColor) {
             Write-Host $Message -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
         }
         Else {

--- a/Public/Connect-LMAccount.ps1
+++ b/Public/Connect-LMAccount.ps1
@@ -52,7 +52,7 @@ PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor
 #>
 Function Connect-LMAccount {
 
-    [CmdletBinding(DefaultParameterSetName="LMv1")]
+    [CmdletBinding(DefaultParameterSetName = "LMv1")]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'LMv1')]
         [String]$AccessId,
@@ -87,8 +87,8 @@ Function Connect-LMAccount {
     )
 
     #Autoload web assembly if on older version of powershell
-    If((Get-Host).Version.Major -lt 6){
-        Add-type -AssemblyName System.Web
+    If ((Get-Host).Version.Major -lt 6) {
+        Add-Type -AssemblyName System.Web
     }
 
     If ($UseCachedCredential -or $CachedAccountName) {
@@ -98,7 +98,7 @@ Function Connect-LMAccount {
             Write-Host "[INFO]: Existing vault Logic.Monitor already exists, skipping creation"
         }
         Catch {
-            If($_.Exception.Message -like "*Vault Logic.Monitor does not exist in registry*") {
+            If ($_.Exception.Message -like "*Vault Logic.Monitor does not exist in registry*") {
                 Write-Host "[INFO]: Credential vault for cached accounts does not currently exist, creating credential vault: Logic.Monitor" 
                 Register-SecretVault -Name Logic.Monitor -ModuleName Microsoft.PowerShell.SecretStore
                 Get-SecretStoreConfiguration | Out-Null
@@ -112,58 +112,58 @@ Function Connect-LMAccount {
             Foreach ($Credential in $CredentialFile) {
                 $CurrentDate = Get-Date
                 [Hashtable]$Metadata = @{
-                    Portal      = [String]$Credential.Portal
-                    Id          = [String]$Credential.Id
-                    Modified    = [DateTime]$CurrentDate
+                    Portal   = [String]$Credential.Portal
+                    Id       = [String]$Credential.Id
+                    Modified = [DateTime]$CurrentDate
                 }
-                Try{
+                Try {
                     Set-Secret -Name $Credential.Portal -Secret $Credential.Key -Vault Logic.Monitor -Metadata $Metadata -NoClobber
                     Write-Host "[INFO]: Successfully migrated cached account secret for portal: $($Credential.Portal)"
                 }
-                Catch{
+                Catch {
                     Write-Error $_.Exception.Message
                     $MigrationComplete = $false
                 }
             }
-            If($MigrationComplete){
+            If ($MigrationComplete) {
                 Remove-Item -Path $CredentialPath -Confirm:$false
                 Write-Host "[INFO]: Successfully migrated cached accounts into secret store, your legacy account cache hes been removed."
             }
-            Else{
+            Else {
                 $NewName = Join-Path -Path $Home -ChildPath "Logic.Monitor-Migrated.json"
                 Rename-Item -Path $CredentialPath -Confirm:$false -NewName $NewName
                 Write-Host "[ERROR]: Unable to fully migrate cached accounts into secret store, your legacy account cache has been archived at: $NewName. No other attemps will be made to migrate any failed accounts." -ForegroundColor Red
             }
         }
 
-        If($CachedAccountName){
+        If ($CachedAccountName) {
             #If supplied and account name just use that vs showing a list of accounts
             $CachedAccountSecrets = Get-SecretInfo -Vault Logic.Monitor
             $CachedAccountIndex = $CachedAccountSecrets.Name.IndexOf($CachedAccountName)
-            If($CachedAccountIndex -ne -1){
+            If ($CachedAccountIndex -ne -1) {
                 $AccountName = $CachedAccountSecrets[$CachedAccountIndex].Metadata["Portal"]
                 $AccessId = $CachedAccountSecrets[$CachedAccountIndex].Metadata["Id"]
                 $Type = $CachedAccountSecrets[$CachedAccountIndex].Metadata["Type"]
-                If(($Type -eq "LMv1") -or ($null -eq $Type)){
+                If (($Type -eq "LMv1") -or ($null -eq $Type)) {
                     [SecureString]$AccessKey = Get-Secret -Vault "Logic.Monitor" -Name $CachedAccountName -AsPlainText | ConvertTo-SecureString
                 }
-                Else{
+                Else {
                     [SecureString]$BearerToken = Get-Secret -Vault "Logic.Monitor" -Name $CachedAccountName -AsPlainText | ConvertTo-SecureString
                 }
             }
-            Else{
+            Else {
                 Write-Error "Entered CachedAccountName ($CachedAccountName) does not match one of the stored credentials, please check the selected entry and try again"
                 Return
             }
         }
-        Else{
+        Else {
             #List out current portals with saved credentials and let users chose which to use
             $i = 0
             $CachedAccountSecrets = Get-SecretInfo -Vault Logic.Monitor
-            If($CachedAccountSecrets){
+            If ($CachedAccountSecrets) {
                 Write-Host "Selection Number | Portal Name"
                 Foreach ($Credential in $CachedAccountSecrets) {
-                    If($Credential.Name -notlike "*LMSessionSync*"){
+                    If ($Credential.Name -notlike "*LMSessionSync*") {
                         Write-Host "$i)     $($Credential.Name)"
                     }
                     $i++
@@ -174,13 +174,13 @@ Function Connect-LMAccount {
                     $CachedAccountName = $CachedAccountSecrets[$StoredCredentialIndex].Name
                     $AccessId = $CachedAccountSecrets[$StoredCredentialIndex].Metadata["Id"]
                     $Type = $CachedAccountSecrets[$StoredCredentialIndex].Metadata["Type"]
-                    If($Type -eq "LMv1"){
+                    If ($Type -eq "LMv1") {
                         [SecureString]$AccessKey = Get-Secret -Vault "Logic.Monitor" -Name $CachedAccountName -AsPlainText | ConvertTo-SecureString
                     }
-                    ElseIf($Type -eq "Bearer"){
+                    ElseIf ($Type -eq "Bearer") {
                         [SecureString]$BearerToken = Get-Secret -Vault "Logic.Monitor" -Name $CachedAccountName -AsPlainText | ConvertTo-SecureString
                     }
-                    Else{
+                    Else {
                         Write-Error "Invalid credential type detected for selection: $Type"
                         Return
                     }
@@ -190,72 +190,72 @@ Function Connect-LMAccount {
                     Return
                 }
             }
-            Else{
+            Else {
                 Write-Error "No entries currently found in secret vault Logic.Monitor"
-                    Return
+                Return
             }
         }
     }
     Else {
-        If($PsCmdlet.ParameterSetName -eq "LMv1"){
+        If ($PsCmdlet.ParameterSetName -eq "LMv1") {
             #Convert to secure string
             [SecureString]$AccessKey = $AccessKey | ConvertTo-SecureString -AsPlainText -Force
             $Type = "LMv1"
         }
-        ElseIf($PsCmdlet.ParameterSetName -eq "SessionSync"){
+        ElseIf ($PsCmdlet.ParameterSetName -eq "SessionSync") {
             $Session = Get-LMSession -AccountName $AccountName
-            If($Session){
-                $AccessId     = $Session.jSessionID #Session Id
-                $AccessKey    = $Session.token #CSRF Token
+            If ($Session) {
+                $AccessId = $Session.jSessionID #Session Id
+                $AccessKey = $Session.token #CSRF Token
                 $Type = "SessionSync"
             }
-            Else{
+            Else {
                 throw "Unable to validate session sync info for: $AccountName"
             }
         }
-        Else{
+        Else {
             #Convert to secure string
             [SecureString]$BearerToken = $BearerToken | ConvertTo-SecureString -AsPlainText -Force
             $Type = "Bearer"
         }
     }
 
-    If(!$Type){
+    If (!$Type) {
         $Type = "LMv1"
     }
     
     #Create Credential Object for reuse in other functions
     $Script:LMAuth = [PSCustomObject]@{
-        Id     = $AccessId
-        Key    = $AccessKey
-        BearerToken    = $BearerToken
-        Portal = $AccountName
-        Valid  = $true
-        Logging = !$DisableConsoleLogging.IsPresent
-        Type = $Type
+        Id          = $AccessId
+        Key         = $AccessKey
+        BearerToken = $BearerToken
+        Portal      = $AccountName
+        Valid       = $true
+        Logging     = !$DisableConsoleLogging.IsPresent
+        Type        = $Type
     }
     
     #Check for newer version of Logic.Monitor module
-    Try{
-        If($AutoUpdateModuleVersion -and !$SkipVersionCheck){
+    Try {
+        If ($AutoUpdateModuleVersion -and !$SkipVersionCheck) {
             Update-LogicMonitorModule
         }
-        ElseIf(!$SkipVersionCheck){
+        ElseIf (!$SkipVersionCheck) {
             Update-LogicMonitorModule -CheckOnly
         }
     }
-    Catch{
+    Catch {
         Write-Host "[ERROR]: Unable to check for newer version of Logic.Monitor module: $($_.Exception.Message)" -ForegroundColor Red
     }
 
-    If(!$SkipCredValidation){
+    If (!$SkipCredValidation) {
         Try {
             #Collect portal info and api username and roles
-            If($Type -eq "Bearer"){
+            If ($Type -eq "Bearer") {
                 $Token = [System.Net.NetworkCredential]::new("", $BearerToken).Password
-                $ApiInfo = Get-LMAPIToken -Type Bearer -ErrorAction SilentlyContinue | Where-Object {$_.accessKey -like "$($Token.Substring(0,20))*"}
+                $ApiInfo = Get-LMAPIToken -Type Bearer -ErrorAction SilentlyContinue | Where-Object { $_.accessKey -like "$($Token.Substring(0,20))*" }
             }
-            Else{
+            Else {
                 $ApiInfo = Get-LMAPIToken -Filter "accessId -eq '$AccessId'" -ErrorAction SilentlyContinue
             }
     
@@ -265,7 +265,7 @@ Function Connect-LMAccount {
                 Return
             }
             Else {
-                Try{
+                Try {
                     $PortalInfo = Get-LMPortalInfo -ErrorAction Stop
                     Write-LMHost "[INFO]: Connected to LM portal $($PortalInfo.companyDisplayName) via $Type Token - ($($PortalInfo.numberOfDevices) devices | $($PortalInfo.numOfWebsites) websites)." -ForegroundColor Green
                     Return
@@ -276,18 +276,18 @@ Function Connect-LMAccount {
             }
         }
         Catch {
-            Try{
+            Try {
                 $DeviceInfo = Get-LMDevice -ErrorAction Stop
     
-                If($DeviceInfo){
+                If ($DeviceInfo) {
                     Write-LMHost "[INFO]: Connected to LM portal $AccountName via $Type Token with limited permissions, ensure your api token has the necessary rights needed to run desired commands." -ForegroundColor Yellow
                     Return
                 }
-                Else{
+                Else {
                     throw "Unable to verify api token permission levels, ensure api token has rights to view all/select resources or at minimum view access for Account Information"
                 }
             }
-            Catch{
+            Catch {
     
                 #Clear credential object from environment
                 Remove-Variable LMAuth -Scope Script -ErrorAction SilentlyContinue
@@ -296,7 +296,7 @@ Function Connect-LMAccount {
             Return
         }
     }
-    Else{
+    Else {
         Write-LMHost "[INFO]: Skipping validation of credentials, connected to LM portal $AccountName via $Type, ensure your api token has the necessary rights needed to run desired commands." -ForegroundColor Yellow
     }
 }

--- a/Public/Connect-LMAccount.ps1
+++ b/Public/Connect-LMAccount.ps1
@@ -177,7 +177,7 @@ Function Connect-LMAccount {
                     If ($Type -eq "LMv1") {
                         [SecureString]$AccessKey = Get-Secret -Vault "Logic.Monitor" -Name $CachedAccountName -AsPlainText | ConvertTo-SecureString
                     }
-                    ElseIf ($Type -eq "Bearer") {
+                    Elseif ($Type -eq "Bearer") {
                         [SecureString]$BearerToken = Get-Secret -Vault "Logic.Monitor" -Name $CachedAccountName -AsPlainText | ConvertTo-SecureString
                     }
                     Else {
@@ -202,7 +202,7 @@ Function Connect-LMAccount {
             [SecureString]$AccessKey = $AccessKey | ConvertTo-SecureString -AsPlainText -Force
             $Type = "LMv1"
         }
-        ElseIf ($PsCmdlet.ParameterSetName -eq "SessionSync") {
+        Elseif ($PsCmdlet.ParameterSetName -eq "SessionSync") {
             $Session = Get-LMSession -AccountName $AccountName
             If ($Session) {
                 $AccessId = $Session.jSessionID #Session Id
@@ -210,7 +210,7 @@ Function Connect-LMAccount {
                 $Type = "SessionSync"
             }
             Else {
-                throw "Unable to validate session sync info for: $AccountName"
+                Throw "Unable to validate session sync info for: $AccountName"
             }
         }
         Else {
@@ -240,7 +240,7 @@ Function Connect-LMAccount {
         If ($AutoUpdateModuleVersion -and !$SkipVersionCheck) {
             Update-LogicMonitorModule
         }
-        ElseIf (!$SkipVersionCheck) {
+        Elseif (!$SkipVersionCheck) {
             Update-LogicMonitorModule -CheckOnly
         }
     }
@@ -271,7 +271,7 @@ Function Connect-LMAccount {
                     Return
                 }
                 Catch {
-                    throw "Unable to validate API token info"
+                    Throw "Unable to validate API token info"
                 }
             }
         }
@@ -284,14 +284,14 @@ Function Connect-LMAccount {
                     Return
                 }
                 Else {
-                    throw "Unable to verify api token permission levels, ensure api token has rights to view all/select resources or at minimum view access for Account Information"
+                    Throw "Unable to verify api token permission levels, ensure api token has rights to view all/select resources or at minimum view access for Account Information"
                 }
             }
             Catch {
     
                 #Clear credential object from environment
                 Remove-Variable LMAuth -Scope Script -ErrorAction SilentlyContinue
-                throw "Unable to login to account, please ensure your access info and account name are correct: $($_.Exception.Message)"
+                Throw "Unable to login to account, please ensure your access info and account name are correct: $($_.Exception.Message)"
             }
             Return
         }

--- a/Public/Copy-LMDashboard.ps1
+++ b/Public/Copy-LMDashboard.ps1
@@ -76,7 +76,7 @@ Function Copy-LMDashboard {
         }
 
         #Lookup Dashboard Id
-        If($DashboardName) {
+        If ($DashboardName) {
             $LookupResult = (Get-LMDashboard -Name $DashboardName).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DashboardName) {
                 return
@@ -92,13 +92,13 @@ Function Copy-LMDashboard {
 
         Try {
             $Data = @{
-                name                                = $Name
-                description                         = $Description
-                groupId                             = $ParentGroupId
-                widgetTokens                        = $SourceDashboard.widgetTokens
-                widgetsConfig                       = $SourceDashboard.widgetsConfig
-                widgetsOrder                        = $SourceDashboard.widgetsOrder
-                sharable                           = $SourceDashboard.sharable
+                name          = $Name
+                description   = $Description
+                groupId       = $ParentGroupId
+                widgetTokens  = $SourceDashboard.widgetTokens
+                widgetsConfig = $SourceDashboard.widgetsConfig
+                widgetsOrder  = $SourceDashboard.widgetsOrder
+                sharable      = $SourceDashboard.sharable
             }
 
             $Data = ($Data | ConvertTo-Json)
@@ -108,7 +108,7 @@ Function Copy-LMDashboard {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/Copy-LMDevice.ps1
+++ b/Public/Copy-LMDevice.ps1
@@ -47,25 +47,25 @@ Function Copy-LMDevice {
     Process {
         If ($Script:LMAuth.Valid) {
             #Strip out dynamic groups
-            $HostGroupIds = ($DeviceObjec.hostGroupIds -Split "," | Get-LMDeviceGroup | Where-Object {$_.appliesTo -eq ""}).Id -Join ","
+            $HostGroupIds = ($DeviceObjec.hostGroupIds -Split "," | Get-LMDeviceGroup | Where-Object { $_.appliesTo -eq "" }).Id -Join ","
 
             $Data = @{
-                name                      = $Name
-                displayName               = If($DisplayName){$DisplayName}Else{$DeviceObject.displayName}
-                description               = If($Description){$Description}Else{$DeviceObject.description}
-                disableAlerting           = $DeviceObject.disableAlerting
-                enableNetflow             = $DeviceObject.enableNetFlow
-                customProperties          = $DeviceObject.customProperties
-                deviceType                = $DeviceObject.deviceType
-                preferredCollectorId      = $DeviceObject.preferredCollectorId
-                preferredCollectorGroupId = $DeviceObject.preferredCollectorGroupId
+                name                         = $Name
+                displayName                  = If ($DisplayName) { $DisplayName }Else { $DeviceObject.displayName }
+                description                  = If ($Description) { $Description }Else { $DeviceObject.description }
+                disableAlerting              = $DeviceObject.disableAlerting
+                enableNetflow                = $DeviceObject.enableNetFlow
+                customProperties             = $DeviceObject.customProperties
+                deviceType                   = $DeviceObject.deviceType
+                preferredCollectorId         = $DeviceObject.preferredCollectorId
+                preferredCollectorGroupId    = $DeviceObject.preferredCollectorGroupId
                 autoBalancedCollectorGroupId = $DeviceObject.autoBalancedCollectorGroupId
-                link                      = $DeviceObject.link
-                netflowCollectorGroupId   = $DeviceObject.netflowCollectorGroupId
-                netflowCollectorId        = $DeviceObject.netflowCollectorId
-                logCollectorGroupId       = $DeviceObject.logCollectorGroupId
-                logCollectorId            = $DeviceObject.logCollectorId
-                hostGroupIds              = If($HostGroupIds){$HostGroupIds}Else{1}
+                link                         = $DeviceObject.link
+                netflowCollectorGroupId      = $DeviceObject.netflowCollectorGroupId
+                netflowCollectorId           = $DeviceObject.netflowCollectorId
+                logCollectorGroupId          = $DeviceObject.logCollectorGroupId
+                logCollectorId               = $DeviceObject.logCollectorId
+                hostGroupIds                 = If ($HostGroupIds) { $HostGroupIds }Else { 1 }
             }
                     
             #Build header and uri

--- a/Public/Copy-LMReport.ps1
+++ b/Public/Copy-LMReport.ps1
@@ -48,8 +48,8 @@ Function Copy-LMReport {
 
         #Replace name and description if present
         $ReportObject.name = $Name
-        If($Description){$ReportObject.description = $Description}
-        If($ParentGroupId){$ReportObject.groupId = $ParentGroupId}
+        If ($Description) { $ReportObject.description = $Description }
+        If ($ParentGroupId) { $ReportObject.groupId = $ParentGroupId }
         
         #Build header and uri
         $ResourcePath = "/report/reports"

--- a/Public/Export-LMDeviceConfigBackup.ps1
+++ b/Public/Export-LMDeviceConfigBackup.ps1
@@ -39,12 +39,12 @@ PSGallery: https://www.powershellgallery.com/packages/Logic.Monitor
 
 Function Export-LMDeviceConfigBackup {
 
-    [CmdletBinding(DefaultParameterSetName="Device")]
+    [CmdletBinding(DefaultParameterSetName = "Device")]
     Param (
-        [Parameter(ParameterSetName="DeviceGroup",Mandatory)]
+        [Parameter(ParameterSetName = "DeviceGroup", Mandatory)]
         [Int]$DeviceGroupId,
         
-        [Parameter(ParameterSetName="Device",Mandatory)]
+        [Parameter(ParameterSetName = "Device", Mandatory)]
         [Int]$DeviceId,
 
         [Regex]$InstanceNameFilter = "[rR]unning|[cC]urrent|[pP]aloAlto",
@@ -58,7 +58,7 @@ Function Export-LMDeviceConfigBackup {
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If($DeviceId){
+        If ($DeviceId) {
             $network_devices = Get-LMDevice -id $DeviceId
         }
         Else {
@@ -77,9 +77,9 @@ Function Export-LMDeviceConfigBackup {
             $filtered_config_instance_count = 0
             Foreach ($config_source in $device_config_sources) {
                 $running_config_instance = Get-LMDeviceDatasourceInstance -DeviceId $config_source.deviceId -DatasourceId $config_source.dataSourceId
-                $filtered_config_instance = $running_config_instance | Where-Object { $_.displayName -Match $InstanceNameFilter}
+                $filtered_config_instance = $running_config_instance | Where-Object { $_.displayName -Match $InstanceNameFilter }
                 If ($filtered_config_instance) {
-                    Foreach($instance in $filtered_config_instance){
+                    Foreach ($instance in $filtered_config_instance) {
                         $filtered_config_instance_count++
                         $instance_list += [PSCustomObject]@{
                             deviceId              = $device.id
@@ -94,7 +94,7 @@ Function Export-LMDeviceConfigBackup {
                     }
                 }
             }
-            Write-LMHost " [INFO]: Found $filtered_config_instance_count configsource instance(s) using match filter ($InstanceNameFilter)."  -ForegroundColor Gray
+            Write-LMHost " [INFO]: Found $filtered_config_instance_count configsource instance(s) using match filter ($InstanceNameFilter)." -ForegroundColor Gray
         }
 
         #Loop through filtered instance list and pull config diff
@@ -112,7 +112,7 @@ Function Export-LMDeviceConfigBackup {
             #Loop through each set and built report
             Foreach ($device in $config_grouping) {
                 $config = $device.Group | Sort-Object -Property pollTimestamp -Descending | Select-Object -First 1
-                Write-LMHost " [INFO]: Found $(($device.Group | Measure-Object).Count) configsource instance version(s) for: $($config.deviceDisplayName), selecting latest config dated: $([datetimeoffset]::FromUnixTimeMilliseconds($config.pollTimestamp).DateTime)UTC"  -ForegroundColor Gray
+                Write-LMHost " [INFO]: Found $(($device.Group | Measure-Object).Count) configsource instance version(s) for: $($config.deviceDisplayName), selecting latest config dated: $([datetimeoffset]::FromUnixTimeMilliseconds($config.pollTimestamp).DateTime)UTC" -ForegroundColor Gray
                 $output_list += [PSCustomObject]@{
                     deviceDisplayName        = $config.deviceDisplayName
                     deviceInstanceName       = $config.instanceName
@@ -125,14 +125,14 @@ Function Export-LMDeviceConfigBackup {
             }
         }
 
-        If($output_list){
-            If($Path){
+        If ($output_list) {
+            If ($Path) {
                 #Generate CSV Export
                 $output_list | Export-Csv -Path $Path -NoTypeInformation
             }
             Return (Add-ObjectTypeInfo -InputObject $output_list -TypeName "LogicMonitor.ConfigBackup" )
         }
-        Else{
+        Else {
             Write-LMHost "[WARN]: Did not find any configs to output based on selected resource(s), check your parameters and try again." -ForegroundColor Yellow
         }
         

--- a/Public/Export-LMDeviceData.ps1
+++ b/Public/Export-LMDeviceData.ps1
@@ -86,7 +86,7 @@ Function Export-LMDeviceData {
     If ($Script:LMAuth.Valid) {
         $DeviceList = @()
         $DataExportList = @()
-        Switch($PSCmdlet.ParameterSetName){
+        Switch ($PSCmdlet.ParameterSetName) {
             "DeviceId" { $DeviceList = Get-LMDevice -Id $DeviceId }
             "DeviceName" { $DeviceList = Get-LMDevice -DisplayName $DeviceName }
             "DeviceHostName" { $DeviceList = Get-LMDevice -Name $DeviceHostName }
@@ -94,33 +94,33 @@ Function Export-LMDeviceData {
             "DeviceGroupName" { $DeviceList = Get-LMDeviceGroupDevices -Name $DeviceGroupName }
         }
 
-        If($DeviceList){
+        If ($DeviceList) {
             Write-LMHost "[INFO]: $(($DeviceList | Measure-Object).count) resource(s) selected for data export"
-            Foreach($Device in $DeviceList){
+            Foreach ($Device in $DeviceList) {
                 $DatasourceList = @()
                 Write-LMHost "[INFO]: Starting data collection for resource: $($Device.displayName)"
-                $DatasourceList = Get-LMDeviceDatasourceList -Id $Device.id | Where-Object { $_.monitoringInstanceNumber -gt 0 -and $_.dataSourceName -like $DatasourceIncludeFilter -and $_.datasourceName -notlike $DatasourceExcludeFilter}
-                If($DatasourceList){
+                $DatasourceList = Get-LMDeviceDatasourceList -Id $Device.id | Where-Object { $_.monitoringInstanceNumber -gt 0 -and $_.dataSourceName -like $DatasourceIncludeFilter -and $_.datasourceName -notlike $DatasourceExcludeFilter }
+                If ($DatasourceList) {
                     Write-LMHost "[INFO]: Found ($(($DatasourceList | Measure-Object).count)) datasource(s) with 1 or more active instances for resource: $($Device.displayName) using datasource filter (Include:$DatasourceIncludeFilter | Exclude:$DatasourceExcludeFilter)"
-                    Foreach($Datasource in $DatasourceList){
+                    Foreach ($Datasource in $DatasourceList) {
                         Write-LMHost "[INFO]: Starting instance discovery for datasource $($Datasource.dataSourceName) for resource: $($Device.displayName)"
                         $InstanceList = @()
-                        $InstanceList = Get-LMDeviceDatasourceInstance -Id $Device.id -DatasourceId $Datasource.dataSourceId | Where-Object { $_.stopMonitoring -eq $false}
-                        If($InstanceList){
+                        $InstanceList = Get-LMDeviceDatasourceInstance -Id $Device.id -DatasourceId $Datasource.dataSourceId | Where-Object { $_.stopMonitoring -eq $false }
+                        If ($InstanceList) {
                             Write-LMHost "[INFO]: Found ($(($InstanceList | Measure-Object).count)) instance(s) for resource: $($Device.displayName)"
-                            Foreach($Instance in $InstanceList){
+                            Foreach ($Instance in $InstanceList) {
                                 Write-LMHost "[INFO]: Starting datapoint collection for instance $($Instance.name) for resource: $($Device.displayName)"
                                 $Datapoints = @()
                                 $Datapoints = Get-LMDeviceData -DeviceId $Device.id -DatasourceId $Datasource.dataSourceId -InstanceId $Instance.id -StartDate $StartDate -EndDate $EndDate
-                                If($Datapoints){
+                                If ($Datapoints) {
                                     Write-LMHost "[INFO]: Finished datapoint collection for instance $($Instance.name) for resource: $($Device.displayName)"
                                     $DataExportList += [PSCustomObject]@{
-                                        deviceId = $Device.id
-                                        deviceName = $Device.displayName
+                                        deviceId       = $Device.id
+                                        deviceName     = $Device.displayName
                                         datasourceName = $Datasource.dataSourceName
-                                        instanceName = $Instance.name
-                                        instanceGroup = $Instance.groupName
-                                        dataPoints = $Datapoints
+                                        instanceName   = $Instance.name
+                                        instanceGroup  = $Instance.groupName
+                                        dataPoints     = $Datapoints
                                     }
                                 }
                             }
@@ -129,13 +129,13 @@ Function Export-LMDeviceData {
                 }
             }
             
-            Switch($ExportFormat){
+            Switch ($ExportFormat) {
                 "json" { $DataExportList | ConvertTo-Json -Depth 3 | Out-File -FilePath "$ExportPath\LMDeviceDataExport.json" ; return }
-                "csv" { $DataExportList | Export-Csv -NoTypeInformation -Path  "$ExportPath\LMDeviceDataExport.csv" ;  return }
+                "csv" { $DataExportList | Export-Csv -NoTypeInformation -Path "$ExportPath\LMDeviceDataExport.csv" ; return }
                 default { return $DataExportList }
             }
         }
-        Else{
+        Else {
             Write-Error "No resources found using supplied parameters, please check you settings and try again."
         }
         

--- a/Public/Export-LMLogicModule.ps1
+++ b/Public/Export-LMLogicModule.ps1
@@ -52,10 +52,10 @@ Function Export-LMLogicModule {
 
         [String]$DownloadPath = (Get-Location).Path
     )
-    Begin{
+    Begin {
 
     }
-    Process{
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -155,5 +155,5 @@ Function Export-LMLogicModule {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Get-LMAPIToken.ps1
+++ b/Public/Get-LMAPIToken.ps1
@@ -65,7 +65,7 @@ Function Get-LMAPIToken {
         [ValidateSet("LMv1", "Bearer", "*")]
         [String]$Type = "*",
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -80,7 +80,7 @@ Function Get-LMAPIToken {
         $Done = $false
         $Results = @()
 
-        If($Type -eq "Bearer"){
+        If ($Type -eq "Bearer") {
             $BearerParam = "&type=bearer"
         }
 

--- a/Public/Get-LMAccessGroup.ps1
+++ b/Public/Get-LMAccessGroup.ps1
@@ -45,7 +45,7 @@ Function Get-LMAccessGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMAccessGroup.ps1
+++ b/Public/Get-LMAccessGroup.ps1
@@ -26,7 +26,7 @@ Get-LMAccessGroup -Name "MyAccessGroup"
 Retrieves the access group with the specified name.
 
 .EXAMPLE
-Get-LMAccessGroup -Filter @{ Property = "Value" }
+Get-LMAccessGroup -Filter "tenantId -eq 'Value'"
 Retrieves access groups based on the specified filter criteria.
 
 .NOTES
@@ -88,7 +88,7 @@ Function Get-LMAccessGroup {
                 #Stop looping if single device, no need to continue
                 If ($PSCmdlet.ParameterSetName -eq "Id") {
                     $Done = $true
-                    Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Role" )
+                    Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.AccessGroup" )
                 }
                 #Check result size and if needed loop again
                 Else {
@@ -107,7 +107,7 @@ Function Get-LMAccessGroup {
                 }
             }
         }
-        Return (Add-ObjectTypeInfo -InputObject $Results -TypeName "LogicMonitor.Role" )
+        Return (Add-ObjectTypeInfo -InputObject $Results -TypeName "LogicMonitor.AccessGroup" )
     }
     Else {
         Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."

--- a/Public/Get-LMAccountStatus.ps1
+++ b/Public/Get-LMAccountStatus.ps1
@@ -26,10 +26,10 @@ Function Get-LMAccountStatus {
     #Clear credential object from environment
     If ($Script:LMAuth) {
         $Result = [PSCustomObject]@{
-            Portal = $Script:LMAuth.Portal
-            Valid = $Script:LMAuth.Valid
+            Portal  = $Script:LMAuth.Portal
+            Valid   = $Script:LMAuth.Valid
             Logging = $Script:LMAuth.Logging
-            Type = $Script:LMAuth.Type
+            Type    = $Script:LMAuth.Type
         }
         return $Result
     }

--- a/Public/Get-LMAlert.ps1
+++ b/Public/Get-LMAlert.ps1
@@ -56,13 +56,13 @@ Function Get-LMAlert {
         [Parameter(ParameterSetName = 'Range')]
         [Datetime]$EndDate,
 
-        [Parameter(Mandatory,ParameterSetName = 'Id')]
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
         [String]$Id,
 
         [ValidateSet("*", "Warning", "Error", "Critical")]
         [String]$Severity = "*",
 
-        [ValidateSet("*", "websiteAlert", "dataSourceAlert", "eventSourceAlert","logAlert")]
+        [ValidateSet("*", "websiteAlert", "dataSourceAlert", "eventSourceAlert", "logAlert")]
         [String]$Type = "*",
 
         [Boolean]$ClearedAlerts = $false,
@@ -73,7 +73,7 @@ Function Get-LMAlert {
         [Parameter(ParameterSetName = 'Id')]
         [String[]]$CustomColumns,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000,
 
         [String]$Sort = "resourceId"
@@ -116,16 +116,16 @@ Function Get-LMAlert {
                     $resourcePath += "/$Id" 
                 
                     #Check if we need to add customColumns
-                    If($CustomColumns){
+                    If ($CustomColumns) {
                         $FormatedColumns = @()
-                        Foreach($Column in $CustomColumns){
+                        Foreach ($Column in $CustomColumns) {
                             $FormatedColumns += [System.Web.HTTPUtility]::UrlEncode($Column)
                         }
 
-                        If($QueryParams){
+                        If ($QueryParams) {
                             $QueryParams += "&customColumns=$($FormatedColumns -join ",")"
                         }
-                        Else{
+                        Else {
                             $QueryParams = "?customColumns=$($FormatedColumns -join",")"
                         }
                     }

--- a/Public/Get-LMAlert.ps1
+++ b/Public/Get-LMAlert.ps1
@@ -164,7 +164,7 @@ Function Get-LMAlert {
                         $Done = $true
                         Write-LMHost "[WARN]: Reached $QueryLimit record query limitation for this endpoint" -ForegroundColor Yellow
                     }
-                    ElseIf ($Count -ge $Total -and $Total -ge 0) {
+                    Elseif ($Count -ge $Total -and $Total -ge 0) {
                         $Done = $true
                     }
                 }

--- a/Public/Get-LMAlertRule.ps1
+++ b/Public/Get-LMAlertRule.ps1
@@ -41,7 +41,7 @@ Function Get-LMAlertRule {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMAppliesToFunction.ps1
+++ b/Public/Get-LMAppliesToFunction.ps1
@@ -49,7 +49,7 @@ Function Get-LMAppliesToFunction {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMAuditLogs.ps1
+++ b/Public/Get-LMAuditLogs.ps1
@@ -53,7 +53,7 @@ Function Get-LMAuditLogs {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -71,7 +71,7 @@ Function Get-LMAuditLogs {
 
         #Convert to epoch, if not set use defaults
         If (!$StartDate) {
-            If($PSCmdlet.ParameterSetName -ne "Id"){
+            If ($PSCmdlet.ParameterSetName -ne "Id") {
                 Write-LMHost "[WARN]: No start date specified, defaulting to last 30 days" -ForegroundColor Yellow
             }
             [int]$StartDate = ([DateTimeOffset]$(Get-Date).AddDays(-30)).ToUnixTimeSeconds()

--- a/Public/Get-LMAuditLogs.ps1
+++ b/Public/Get-LMAuditLogs.ps1
@@ -125,7 +125,7 @@ Function Get-LMAuditLogs {
                         $Done = $true
                         Write-LMHost "[WARN]: Reached $QueryLimit record query limitation for this endpoint" -ForegroundColor Yellow
                     }
-                    ElseIf ($Count -ge $Total -and $Total -ge 0) {
+                    Elseif ($Count -ge $Total -and $Total -ge 0) {
                         $Done = $true
                     }
                 }

--- a/Public/Get-LMCachedAccount.ps1
+++ b/Public/Get-LMCachedAccount.ps1
@@ -41,20 +41,20 @@ Function Get-LMCachedAccount {
     Param (
         [String]$CachedAccountName
     )
-    If($CachedAccountName){
+    If ($CachedAccountName) {
         $CachedAccountSecrets = Get-SecretInfo -Vault Logic.Monitor -Name $CachedAccountName
     }
-    Else{
+    Else {
         $CachedAccountSecrets = Get-SecretInfo -Vault Logic.Monitor
     }
     $CachedAccounts = @()
-    Foreach ($Secret in $CachedAccountSecrets){
+    Foreach ($Secret in $CachedAccountSecrets) {
         $CachedAccounts += [PSCustomObject]@{
-            CachedAccountName      = $Secret.Name
-            Portal      = $Secret.Metadata["Portal"]
-            Id          = If(!$Secret.Metadata["Id"]){"N/A"}Else{$Secret.Metadata["Id"]}
-            Modified    = $Secret.Metadata["Modified"]
-            Type    = If(!$Secret.Metadata["Type"]){"LMv1"}Else{$Secret.Metadata["Type"]}
+            CachedAccountName = $Secret.Name
+            Portal            = $Secret.Metadata["Portal"]
+            Id                = If (!$Secret.Metadata["Id"]) { "N/A" }Else { $Secret.Metadata["Id"] }
+            Modified          = $Secret.Metadata["Modified"]
+            Type              = If (!$Secret.Metadata["Type"]) { "LMv1" }Else { $Secret.Metadata["Type"] }
         }
     }
     Return $CachedAccounts

--- a/Public/Get-LMCollector.ps1
+++ b/Public/Get-LMCollector.ps1
@@ -45,7 +45,7 @@ Function Get-LMCollector {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMCollectorGroup.ps1
+++ b/Public/Get-LMCollectorGroup.ps1
@@ -43,7 +43,7 @@ Function Get-LMCollectorGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMCollectorInstaller.ps1
+++ b/Public/Get-LMCollectorInstaller.ps1
@@ -43,7 +43,7 @@ Function Get-LMCollectorInstaller {
         [Parameter(Mandatory, ParameterSetName = "Name")]
         [string]$Name,
 
-        [ValidateSet("nano", "small", "medium", "large", "extra_large","double_extra_large")]
+        [ValidateSet("nano", "small", "medium", "large", "extra_large", "double_extra_large")]
         [string]$Size = "medium",
 
         [ValidateSet("Win64", "Linux64")]
@@ -84,7 +84,7 @@ Function Get-LMCollectorInstaller {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+            #Issue request
             Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1] -OutFile $DownloadPath
             
             Return $DownloadPath

--- a/Public/Get-LMCollectorVersions.ps1
+++ b/Public/Get-LMCollectorVersions.ps1
@@ -46,7 +46,7 @@ Function Get-LMCollectorVersions {
         [Parameter(ParameterSetName = 'Top')]
         [Switch]$TopVersions,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMConfigSource.ps1
+++ b/Public/Get-LMConfigSource.ps1
@@ -45,7 +45,7 @@ Function Get-LMConfigSource {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDashboard.ps1
+++ b/Public/Get-LMDashboard.ps1
@@ -75,7 +75,7 @@ Function Get-LMDashboard {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
 

--- a/Public/Get-LMDashboardGroup.ps1
+++ b/Public/Get-LMDashboardGroup.ps1
@@ -17,7 +17,7 @@ Function Get-LMDashboardGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDashboardWidget.ps1
+++ b/Public/Get-LMDashboardWidget.ps1
@@ -17,7 +17,7 @@ Function Get-LMDashboardWidget {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDatasource.ps1
+++ b/Public/Get-LMDatasource.ps1
@@ -14,7 +14,7 @@ Function Get-LMDatasource {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDatasourceAssociatedDevices.ps1
+++ b/Public/Get-LMDatasourceAssociatedDevices.ps1
@@ -13,7 +13,7 @@ Function Get-LMDatasourceAssociatedDevices {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDatasourceGraph.ps1
+++ b/Public/Get-LMDatasourceGraph.ps1
@@ -2,37 +2,37 @@ Function Get-LMDatasourceGraph {
 
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
         [Int]$Id,
 
-        [Parameter(Mandatory,ParameterSetName = 'dsName')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsName')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsName')]
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsName')]
         [String]$DataSourceName,
         
-        [Parameter(Mandatory,ParameterSetName = 'dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsId')]
         [String]$DataSourceId,
         
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [String]$Name,
         
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsName')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If($DataSourceName){
+        If ($DataSourceName) {
             $LookupResult = (Get-LMDatasource -Name $DataSourceName).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DataSourceName) {
                 Return

--- a/Public/Get-LMDatasourceMetadata.ps1
+++ b/Public/Get-LMDatasourceMetadata.ps1
@@ -11,7 +11,7 @@ Function Get-LMDatasourceMetadata {
         [Parameter(ParameterSetName = 'DisplayName')]
         [String]$DisplayName,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -41,29 +41,29 @@ Function Get-LMDatasourceMetadata {
         #Initalize vars
         $QueryParams = ""
 
-            #Build query params
-            $QueryParams = "?size=$BatchSize&offset=$Count&sort=+id"
+        #Build query params
+        $QueryParams = "?size=$BatchSize&offset=$Count&sort=+id"
 
-            Try {
-                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
-                $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath + $QueryParams
+        Try {
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath + $QueryParams
                     
                 
                 
-                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
-                $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
 
-                Return $Response
+            Return $Response
 
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
             }
-            Catch [Exception] {
-                $Proceed = Resolve-LMException -LMException $PSItem
-                If (!$Proceed) {
-                    Return
-                }
-            }
+        }
         Return $Results
     }
     Else {

--- a/Public/Get-LMDatasourceOverviewGraph.ps1
+++ b/Public/Get-LMDatasourceOverviewGraph.ps1
@@ -2,37 +2,37 @@ Function Get-LMDatasourceOverviewGraph {
 
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
         [Int]$Id,
 
-        [Parameter(Mandatory,ParameterSetName = 'dsName')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsName')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsName')]
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsName')]
         [String]$DataSourceName,
         
-        [Parameter(Mandatory,ParameterSetName = 'dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsId')]
         [String]$DataSourceId,
         
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [String]$Name,
         
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsId')]
-        [Parameter(Mandatory,ParameterSetName = 'Filter-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Filter-dsName')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If($DataSourceName){
+        If ($DataSourceName) {
             $LookupResult = (Get-LMDatasource -Name $DataSourceName).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DataSourceName) {
                 Return

--- a/Public/Get-LMDatasourceUpdateHistory.ps1
+++ b/Public/Get-LMDatasourceUpdateHistory.ps1
@@ -13,7 +13,7 @@ Function Get-LMDatasourceUpdateHistory {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDevice.ps1
+++ b/Public/Get-LMDevice.ps1
@@ -73,17 +73,17 @@ Function Get-LMDevice {
         [Parameter(ParameterSetName = 'Delta')]
         [String]$DeltaId,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
         
         #Build header and uri
-        If($Delta -or $DeltaId){
+        If ($Delta -or $DeltaId) {
             $ResourcePath = "/device/devices/delta"
         }
-        Else{
+        Else {
             $ResourcePath = "/device/devices"
         }
 
@@ -110,7 +110,7 @@ Function Get-LMDevice {
                     $QueryParams = "?filter=$ValidFilter&size=$BatchSize&offset=$Count&sort=+id"
                 }
             }
-            If($Delta -and $DeltaIdResponse){
+            If ($Delta -and $DeltaIdResponse) {
                 $QueryParams = $QueryParams + "&deltaId=$DeltaIdResponse"
             }
             Try {
@@ -125,7 +125,7 @@ Function Get-LMDevice {
                 $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
 
                 #Store delta id if delta switch is present
-                If($Response.deltaId -and !$DeltaIdResponse){
+                If ($Response.deltaId -and !$DeltaIdResponse) {
                     $DeltaIdResponse = $Response.deltaId
                     Write-LMHost "[INFO]: Delta switch detected, for further queries you can use deltaId: $DeltaIdResponse to perform additional delta requests. This variable can be accessed by referencing the `$LMDeltaId " -ForegroundColor Yellow
                     Set-Variable -Name "LMDeltaId" -Value $DeltaIdResponse -Scope global

--- a/Public/Get-LMDeviceAlertSettings.ps1
+++ b/Public/Get-LMDeviceAlertSettings.ps1
@@ -10,11 +10,11 @@ Function Get-LMDeviceAlertSettings {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
     
@@ -86,5 +86,5 @@ Function Get-LMDeviceAlertSettings {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Get-LMDeviceAlerts.ps1
+++ b/Public/Get-LMDeviceAlerts.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceAlerts {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceConfigSourceData.ps1
+++ b/Public/Get-LMDeviceConfigSourceData.ps1
@@ -72,7 +72,7 @@ Function Get-LMDeviceConfigSourceData {
                     $Done = $true
                     Return $Response
                 }
-                ElseIf ($LatestConfigOnly) {
+                Elseif ($LatestConfigOnly) {
                     Return $Response.Items
                 }
                 #Check result size and if needed loop again

--- a/Public/Get-LMDeviceConfigSourceData.ps1
+++ b/Public/Get-LMDeviceConfigSourceData.ps1
@@ -35,12 +35,12 @@ Function Get-LMDeviceConfigSourceData {
         $Done = $false
         $Results = @()
 
-        Switch($ConfigType){
-            "Delta" {$ConfigField = "!config"}
-            "Full" {$ConfigField = "!deltaConfig"}
+        Switch ($ConfigType) {
+            "Delta" { $ConfigField = "!config" }
+            "Full" { $ConfigField = "!deltaConfig" }
         }
 
-        If($LatestConfigOnly){
+        If ($LatestConfigOnly) {
             $BatchSize = 1
             $SortParam = "&sort=-pollTimestamp"
         }
@@ -48,11 +48,11 @@ Function Get-LMDeviceConfigSourceData {
         #Loop through requests 
         While (!$Done) {
             #Build query params
-            If($ConfigId){
+            If ($ConfigId) {
                 $ResourcePath = $ResourcePath + "/$ConfigId"
                 $QueryParams = "?deviceId=$Id&deviceDataSourceId=$HdsId&instanceId=$HdsInsId&fields=$ConfigField"
             }
-            Else{
+            Else {
                 $QueryParams = "?size=$BatchSize&offset=$Count&fields=$ConfigField$SortParam"
             }
 
@@ -72,7 +72,7 @@ Function Get-LMDeviceConfigSourceData {
                     $Done = $true
                     Return $Response
                 }
-                ElseIf($LatestConfigOnly){
+                ElseIf ($LatestConfigOnly) {
                     Return $Response.Items
                 }
                 #Check result size and if needed loop again

--- a/Public/Get-LMDeviceData.ps1
+++ b/Public/Get-LMDeviceData.ps1
@@ -44,7 +44,7 @@ Function Get-LMDeviceData {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
 
     )
@@ -85,7 +85,7 @@ Function Get-LMDeviceData {
         #Lookup InstanceId
         If ($InstanceName) {
 
-            $LookupResult = (Get-LMDeviceDatasourceInstance -DeviceId $DeviceId -DatasourceId $DatasourceId | Where-Object { $_.displayName -eq $InstanceName -or $_.name -like "*$InstanceName" -or $_.name -eq "$InstanceName"}).Id
+            $LookupResult = (Get-LMDeviceDatasourceInstance -DeviceId $DeviceId -DatasourceId $DatasourceId | Where-Object { $_.displayName -eq $InstanceName -or $_.name -like "*$InstanceName" -or $_.name -eq "$InstanceName" }).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                 return
             }
@@ -114,7 +114,7 @@ Function Get-LMDeviceData {
             }
 
             #Add time range filter if provided data ranges
-            If($StartDate -and $EndDate){
+            If ($StartDate -and $EndDate) {
                 $QueryParams = $QueryParams + "&start=$StartDate&end=$EndDate"
             }
             
@@ -151,22 +151,22 @@ Function Get-LMDeviceData {
             }
         }
         #Convert results into readable format for consumption
-        If($Response){
+        If ($Response) {
             $DatapointResults = @($null) * ($Response.values | Measure-Object).Count
-            for ($v = 0 ; $v -lt ($Response.values | Measure-Object).Count ; $v++){
-                    $DatapointResults[$v] = [PSCustomObject]@{}
-                    $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampEpoch" -Value $Response.time[$v]
+            for ($v = 0 ; $v -lt ($Response.values | Measure-Object).Count ; $v++) {
+                $DatapointResults[$v] = [PSCustomObject]@{}
+                $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampEpoch" -Value $Response.time[$v]
 
-                    $TimestampConverted = (([System.DateTimeOffset]::FromUnixTimeMilliseconds($Response.time[$v])).DateTime).ToString()
-                    $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampUTC" -Value $TimestampConverted
+                $TimestampConverted = (([System.DateTimeOffset]::FromUnixTimeMilliseconds($Response.time[$v])).DateTime).ToString()
+                $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampUTC" -Value $TimestampConverted
 
-                for ($dp = 0 ; $dp -lt ($Response.dataPoints | Measure-Object).Count; $dp++){
+                for ($dp = 0 ; $dp -lt ($Response.dataPoints | Measure-Object).Count; $dp++) {
                     $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name $Response.dataPoints[$dp] -Value $Response.values[$v][$dp]
                 }
             }
             Return $DatapointResults
         }
-        Else{
+        Else {
             Return
         }
 

--- a/Public/Get-LMDeviceData.ps1
+++ b/Public/Get-LMDeviceData.ps1
@@ -84,6 +84,8 @@ Function Get-LMDeviceData {
 
         #Lookup InstanceId
         If ($InstanceName) {
+            #Replace brakets in instance name
+            $InstanceName = $InstanceName -replace "[\[\]]", "?"
 
             $LookupResult = (Get-LMDeviceDatasourceInstance -DeviceId $DeviceId -DatasourceId $DatasourceId | Where-Object { $_.displayName -eq $InstanceName -or $_.name -like "*$InstanceName" -or $_.name -eq "$InstanceName" }).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {

--- a/Public/Get-LMDeviceDataSourceList.ps1
+++ b/Public/Get-LMDeviceDataSourceList.ps1
@@ -1,11 +1,64 @@
+<#
+.SYNOPSIS
+Retrieves a list of device data sources from LogicMonitor.
+
+.DESCRIPTION
+The Get-LMDeviceDatasourceList function retrieves a list of device data sources from LogicMonitor based on the specified parameters. It supports filtering by device ID or device name, and allows customization of the batch size for pagination.
+
+.PARAMETER Id
+Specifies the ID of the device for which to retrieve the data sources. This parameter is mandatory when using the 'Id' parameter set.
+
+.PARAMETER Name
+Specifies the name of the device for which to retrieve the data sources. This parameter is mandatory when using the 'Name' parameter set.
+
+.PARAMETER Filter
+Specifies additional filters to apply to the data sources. This parameter accepts an object representing the filter criteria.
+
+.PARAMETER BatchSize
+Specifies the number of data sources to retrieve per batch. The default value is 1000.
+
+.EXAMPLE
+Get-LMDeviceDatasourceList -Id 1234
+Retrieves the data sources for the device with ID 1234.
+
+.EXAMPLE
+Get-LMDeviceDatasourceList -Name "MyDevice"
+Retrieves the data sources for the device with the name "MyDevice".
+
+.EXAMPLE
+Get-LMDeviceDatasourceList -Filter "Property -eq 'Value'"
+Retrieves the data sources that match the specified filter criteria.
+
+#>
+Function Get-LMDeviceDatasourceList {
+    [CmdletBinding(DefaultParameterSetName = 'Id')]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
+        [Alias('DeviceId')]
+        [Int]$Id,
+
+        [Parameter(ParameterSetName = 'Name')]
+        [Alias('DeviceName')]
+        [String]$Name,
+
+        [Object]$Filter,
+
+        [ValidateRange(1, 1000)]
+        [Int]$BatchSize = 1000
+    )
+    # Rest of the code...
+}
+
 Function Get-LMDeviceDatasourceList {
 
     [CmdletBinding(DefaultParameterSetName = 'Id')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id')]
+        [Alias('DeviceId')]
         [Int]$Id,
 
         [Parameter(ParameterSetName = 'Name')]
+        [Alias('DeviceName')]
         [String]$Name,
 
         [Object]$Filter,

--- a/Public/Get-LMDeviceDataSourceList.ps1
+++ b/Public/Get-LMDeviceDataSourceList.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceDatasourceList {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceDatasourceInstance.ps1
+++ b/Public/Get-LMDeviceDatasourceInstance.ps1
@@ -1,3 +1,39 @@
+<#
+.SYNOPSIS
+Retrieves instances of a LogicMonitor device datasource.
+
+.DESCRIPTION
+The Get-LMDeviceDatasourceInstance function retrieves instances of a LogicMonitor device datasource based on the specified parameters. It requires a valid API authentication and authorization.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource. This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter sets.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource. This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter sets.
+
+.PARAMETER Id
+Specifies the ID of the device. This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets. It can also be specified using the 'DeviceId' alias.
+
+.PARAMETER Name
+Specifies the name of the device. This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets. It can also be specified using the 'DeviceName' alias.
+
+.PARAMETER Filter
+Specifies additional filters to apply to the instances. This parameter accepts an object representing the filter criteria.
+
+.PARAMETER BatchSize
+Specifies the number of instances to retrieve per batch. The default value is 1000.
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstance -DatasourceName "CPU" -Name "Server01" -BatchSize 500
+Retrieves instances of the "CPU" datasource for the device named "Server01" with a batch size of 500.
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstance -DatasourceId 1234 -Id 5678
+Retrieves instances of the datasource with ID 1234 for the device with ID 5678.
+
+.NOTES
+This function requires a valid API authentication and authorization. Use Connect-LMAccount to log in before running any commands.
+#>
 Function Get-LMDeviceDatasourceInstance {
 
     [CmdletBinding()]
@@ -12,13 +48,13 @@ Function Get-LMDeviceDatasourceInstance {
     
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
-        [Alias("Id")]
-        [Int]$DeviceId,
+        [Alias("DeviceId")]
+        [Int]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
-        [Alias("Name")]
-        [String]$DeviceName,
+        [Alias("DeviceName")]
+        [String]$Name,
 
         [Object]$Filter,
 
@@ -30,17 +66,17 @@ Function Get-LMDeviceDatasourceInstance {
     If ($Script:LMAuth.Valid) {
 
         #Lookup Device Id
-        If ($DeviceName) {
-            $LookupResult = (Get-LMDevice -Name $DeviceName).Id
-            If (Test-LookupResult -Result $LookupResult -LookupString $DeviceName) {
+        If ($Name) {
+            $LookupResult = (Get-LMDevice -Name $Name).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
                 return
             }
-            $DeviceId = $LookupResult
+            $Id = $LookupResult
         }
 
         #Lookup DatasourceId
         If ($DatasourceName -or $DatasourceId) {
-            $LookupResult = (Get-LMDeviceDataSourceList -Id $DeviceId | Where-Object { $_.dataSourceName -eq $DatasourceName -or $_.dataSourceId -eq $DatasourceId }).Id
+            $LookupResult = (Get-LMDeviceDataSourceList -Id $Id | Where-Object { $_.dataSourceName -eq $DatasourceName -or $_.dataSourceId -eq $DatasourceId }).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceName) {
                 return
             }
@@ -48,7 +84,7 @@ Function Get-LMDeviceDatasourceInstance {
         }
         
         #Build header and uri
-        $ResourcePath = "/device/devices/$DeviceId/devicedatasources/$HdsId/instances"
+        $ResourcePath = "/device/devices/$Id/devicedatasources/$HdsId/instances"
 
         #Initalize vars
         $QueryParams = ""

--- a/Public/Get-LMDeviceDatasourceInstance.ps1
+++ b/Public/Get-LMDeviceDatasourceInstance.ps1
@@ -22,7 +22,7 @@ Function Get-LMDeviceDatasourceInstance {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
 
     )

--- a/Public/Get-LMDeviceDatasourceInstanceAlertRecipients.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceAlertRecipients.ps1
@@ -1,0 +1,97 @@
+Function Get-LMDeviceDatasourceInstanceAlertRecipients {
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [String]$DatasourceName,
+    
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Int]$DatasourceId,
+    
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Int]$Id,
+    
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [String]$Name,
+
+        [Parameter(Mandatory)]
+        [String]$InstanceName,
+
+        [Parameter(Mandatory)]
+        [String]$DataPointName
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+
+        #Lookup Device Id
+        If ($Name) {
+            $LookupResult = (Get-LMDevice -Name $Name).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                return
+            }
+            $Id = $LookupResult
+        }
+
+        #Lookup Hdsid
+        If ($DatasourceName -or $DatasourceId) {
+            $LookupResult = (Get-LMDeviceDataSourceList -Id $Id | Where-Object { $_.dataSourceName -eq $DatasourceName -or $_.dataSourceId -eq $DatasourceId }).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceName) {
+                return
+            }
+            $HdsId = $LookupResult
+        }
+        #Lookup HdsiId
+        If ($DatasourceName) {
+            $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
+                return
+            }
+            $HdsiId = $LookupResult
+        }
+        Else{
+            $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
+                return
+            }
+            $HdsiId = $LookupResult
+        }
+
+        #Get datapoint id
+        $LookupResult = (Get-LMDeviceDatasourceInstanceAlertSetting -DatasourceId $DatasourceId -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -like "*$DataPointName"}).Id
+        If (Test-LookupResult -Result $LookupResult -LookupString $DataPointName) {
+            return
+        }
+        $DsidpId = $LookupResult
+        
+        #Build header and uri
+        $ResourcePath = "/device/devices/$Id/devicedatasources/$HdsId/instances/$HdsiId/alertsettings/$DsidpId/recipients"
+
+        #Initalize vars
+        $Results = @()
+
+        Try {
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+            
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+            #Issue request
+            $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
+
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+        Return $Response
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Get-LMDeviceDatasourceInstanceAlertRecipients.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceAlertRecipients.ps1
@@ -1,5 +1,40 @@
-Function Get-LMDeviceDatasourceInstanceAlertRecipients {
+<#
+.SYNOPSIS
+Retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
 
+.DESCRIPTION
+The Get-LMDeviceDatasourceInstanceAlertRecipients function retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance. It requires valid API credentials and a logged-in session.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource. This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter sets.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource. This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter sets.
+
+.PARAMETER Id
+Specifies the ID of the device. This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets. It can also be specified using the 'DeviceId' alias.
+
+.PARAMETER Name
+Specifies the name of the device. This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets. It can also be specified using the 'DeviceName' alias.
+
+.PARAMETER InstanceName
+Specifies the name of the datasource instance. This parameter is mandatory.
+
+.PARAMETER DataPointName
+Specifies the name of the data point. This parameter is mandatory.
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceName "Ping-" -Name "Server01" -InstanceName "Instance01" -DataPointName "PingLossPercent"
+
+Retrieves the alert recipients for the "PingLossPercent" data point in the "CPU" datasource instance of the "Server01" device.
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstanceAlertRecipients -DatasourceId 123 -Id 456 -InstanceName "Instance01" -DataPointName "PingLossPercent"
+
+Retrieves the alert recipients for the "PingLossPercent" data point in the datasource instance with ID 123 of the device with ID 456.
+
+#>
+Function Get-LMDeviceDatasourceInstanceAlertRecipients {
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
@@ -12,10 +47,12 @@ Function Get-LMDeviceDatasourceInstanceAlertRecipients {
     
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Alias('DeviceId')]
         [Int]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Alias('DeviceName')]
         [String]$Name,
 
         [Parameter(Mandatory)]

--- a/Public/Get-LMDeviceDatasourceInstanceAlertRecipients.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceAlertRecipients.ps1
@@ -81,6 +81,10 @@ Function Get-LMDeviceDatasourceInstanceAlertRecipients {
             }
             $HdsId = $LookupResult
         }
+
+        #Replace brakets in instance name
+        $InstanceName = $InstanceName -replace "[\[\]]", "?"
+        
         #Lookup HdsiId
         If ($DatasourceName) {
             $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id

--- a/Public/Get-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -1,3 +1,43 @@
+<#
+.SYNOPSIS
+Retrieves the alert settings for a specific LogicMonitor device datasource instance.
+
+.DESCRIPTION
+The Get-LMDeviceDatasourceInstanceAlertSetting function retrieves the alert settings for a specific LogicMonitor device datasource instance. It requires the device name or ID, datasource name or ID, and instance name as input parameters. Optionally, you can also provide a filter to narrow down the results. The function returns an array of alert settings for the specified instance.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource. This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter set.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource. This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter set.
+
+.PARAMETER Id
+Specifies the ID of the device. This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter set. This parameter can also be specified using the 'DeviceId' alias.
+
+.PARAMETER Name
+Specifies the name of the device. This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter set. This parameter can also be specified using the 'DeviceName' alias.
+
+.PARAMETER InstanceName
+Specifies the name of the instance for which to retrieve the alert settings. This parameter is mandatory.
+
+.PARAMETER Filter
+Specifies a filter to narrow down the results. This parameter is optional.
+
+.PARAMETER BatchSize
+Specifies the number of results to retrieve per batch. The default value is 1000. This parameter is optional.
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstanceAlertSetting -Name "MyDevice" -DatasourceName "MyDatasource" -InstanceName "MyInstance"
+Retrieves the alert settings for the instance named "MyInstance" of the datasource "MyDatasource" on the device named "MyDevice".
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstanceAlertSetting -Id 123 -DatasourceId 456 -InstanceName "MyInstance" -Filter "Property -eq 'value'"
+Retrieves the alert settings for the instance named "MyInstance" of the datasource with ID 456 on the device with ID 123, applying the specified filter.
+
+.NOTES
+This function requires a valid LogicMonitor API authentication. Make sure you are logged in before running any commands by using the Connect-LMAccount function.
+#>
+
 Function Get-LMDeviceDatasourceInstanceAlertSetting {
 
     [CmdletBinding()]
@@ -12,10 +52,12 @@ Function Get-LMDeviceDatasourceInstanceAlertSetting {
     
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Alias('DeviceId')]
         [Int]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Alias('DeviceName')]
         [String]$Name,
 
         [Parameter(Mandatory)]

--- a/Public/Get-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -23,7 +23,7 @@ Function Get-LMDeviceDatasourceInstanceAlertSetting {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
 
     )
@@ -49,14 +49,14 @@ Function Get-LMDeviceDatasourceInstanceAlertSetting {
         }
         #Lookup HdsiId
         If ($DatasourceName) {
-            $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id
+            $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                 return
             }
             $HdsiId = $LookupResult
         }
-        Else{
-            $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id
+        Else {
+            $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                 return
             }

--- a/Public/Get-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -89,6 +89,10 @@ Function Get-LMDeviceDatasourceInstanceAlertSetting {
             }
             $HdsId = $LookupResult
         }
+
+        #Replace brakets in instance name
+        $InstanceName = $InstanceName -replace "[\[\]]", "?"
+        
         #Lookup HdsiId
         If ($DatasourceName) {
             $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id

--- a/Public/Get-LMDeviceDatasourceInstanceGroup.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceGroup.ps1
@@ -1,3 +1,45 @@
+<#
+.SYNOPSIS
+Retrieves the instance groups associated with a LogicMonitor device datasource.
+
+.DESCRIPTION
+The Get-LMDeviceDatasourceInstanceGroup function retrieves the instance groups associated with a LogicMonitor device datasource. It requires valid API credentials and a logged-in session.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource. This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter sets.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource. This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter sets.
+
+.PARAMETER Id
+Specifies the ID of the device. This parameter is mandatory when using the 'Id-dsId', 'Id-dsName', or 'Id-HdsId' parameter sets. This parameter is also aliased as 'DeviceId'.
+
+.PARAMETER Name
+Specifies the name of the device. This parameter is mandatory when using the 'Name-dsName', 'Name-dsId', or 'Name-HdsId' parameter sets. This parameter is also aliased as 'DeviceName'.
+
+.PARAMETER HdsId
+Specifies the ID of the device datasource. This parameter is mandatory when using the 'Id-HdsId' or 'Name-HdsId' parameter sets.
+
+.PARAMETER Filter
+Specifies an optional filter to apply to the results.
+
+.PARAMETER BatchSize
+Specifies the number of results to retrieve per batch. The default value is 1000.
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstanceGroup -DatasourceName "CPU" -Name "Server01"
+Retrieves the instance groups associated with the "CPU" datasource on the device named "Server01".
+
+.EXAMPLE
+Get-LMDeviceDatasourceInstanceGroup -DatasourceId 123 -Id 456
+Retrieves the instance groups associated with the datasource with ID 123 on the device with ID 456.
+
+#>
+
+Function Get-LMDeviceDatasourceInstanceGroup {
+    ...
+}
+
 Function Get-LMDeviceDatasourceInstanceGroup {
 
     [CmdletBinding()]
@@ -13,11 +55,13 @@ Function Get-LMDeviceDatasourceInstanceGroup {
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Id-HdsId')]
+        [Alias('DeviceId')]
         [Int]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Name-HdsId')]
+        [Alias('DeviceName')]
         [String]$Name,
 
         [Parameter(Mandatory, ParameterSetName = 'Id-HdsId')]

--- a/Public/Get-LMDeviceDatasourceInstanceGroup.ps1
+++ b/Public/Get-LMDeviceDatasourceInstanceGroup.ps1
@@ -26,7 +26,7 @@ Function Get-LMDeviceDatasourceInstanceGroup {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
 
     )

--- a/Public/Get-LMDeviceEventSourceList.ps1
+++ b/Public/Get-LMDeviceEventSourceList.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceEventSourceList {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroup.ps1
+++ b/Public/Get-LMDeviceGroup.ps1
@@ -41,7 +41,7 @@ Function Get-LMDeviceGroup {
 
     [CmdletBinding(DefaultParameterSetName = 'All')]
     Param (
-        [Parameter(ParameterSetName = 'Id',ValueFromPipeline)]
+        [Parameter(ParameterSetName = 'Id', ValueFromPipeline)]
         [Int]$Id,
 
         [Parameter(ParameterSetName = 'Name')]
@@ -50,7 +50,7 @@ Function Get-LMDeviceGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -120,5 +120,5 @@ Function Get-LMDeviceGroup {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Get-LMDeviceGroupAlerts.ps1
+++ b/Public/Get-LMDeviceGroupAlerts.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceGroupAlerts {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroupDatasourceAlertSetting.ps1
+++ b/Public/Get-LMDeviceGroupDatasourceAlertSetting.ps1
@@ -21,7 +21,7 @@ Function Get-LMDeviceGroupDatasourceAlertSetting {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroupDatasourceList.ps1
+++ b/Public/Get-LMDeviceGroupDatasourceList.ps1
@@ -11,7 +11,7 @@ Function Get-LMDeviceGroupDatasourceList {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroupDevices.ps1
+++ b/Public/Get-LMDeviceGroupDevices.ps1
@@ -12,7 +12,7 @@ Function Get-LMDeviceGroupDevices {
 
         [Boolean]$IncludeSubGroups = $false,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -65,7 +65,7 @@ Function Get-LMDeviceGroupDevices {
                 
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
 
                     #Stop looping if single device, no need to continue
@@ -92,7 +92,7 @@ Function Get-LMDeviceGroupDevices {
             }
             #Dedupe results
         }
-        If($Results){
+        If ($Results) {
             $Results = ($Results | Sort-Object -Property Id -Unique)
         }
         Return (Add-ObjectTypeInfo -InputObject $Results -TypeName "LogicMonitor.Device" )

--- a/Public/Get-LMDeviceGroupGroups.ps1
+++ b/Public/Get-LMDeviceGroupGroups.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceGroupGroups {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroupProperty.ps1
+++ b/Public/Get-LMDeviceGroupProperty.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceGroupProperty {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroupSDT.ps1
+++ b/Public/Get-LMDeviceGroupSDT.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceGroupSDT {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceGroupSDTHistory.ps1
+++ b/Public/Get-LMDeviceGroupSDTHistory.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceGroupSDTHistory {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceInstanceData.ps1
+++ b/Public/Get-LMDeviceInstanceData.ps1
@@ -56,7 +56,7 @@ Function Get-LMDeviceInstanceData {
 
         #Convert to epoch, if not set use defaults
         If (!$StartDate) {
-            [int]$StartDate =  ([DateTimeOffset]$(Get-Date).AddHours(-24)).ToUnixTimeSeconds()
+            [int]$StartDate = ([DateTimeOffset]$(Get-Date).AddHours(-24)).ToUnixTimeSeconds()
         }
         Else {
             [int]$StartDate = ([DateTimeOffset]$($StartDate)).ToUnixTimeSeconds()

--- a/Public/Get-LMDeviceInstanceList.ps1
+++ b/Public/Get-LMDeviceInstanceList.ps1
@@ -63,7 +63,6 @@ Function Get-LMDeviceInstanceList {
                     return $Response.Total
                 }
 
-
                 #Stop looping if single device, no need to continue
                 If (![bool]$Response.psobject.Properties["total"]) {
                     $Done = $true

--- a/Public/Get-LMDeviceInstanceList.ps1
+++ b/Public/Get-LMDeviceInstanceList.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceInstanceList {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000,
 
         [Boolean]$CountOnly

--- a/Public/Get-LMDeviceNetflowEndpoints.ps1
+++ b/Public/Get-LMDeviceNetflowEndpoints.ps1
@@ -14,7 +14,7 @@ Function Get-LMDeviceNetflowEndpoints {
 
         [Datetime]$EndDate,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceNetflowFlows.ps1
+++ b/Public/Get-LMDeviceNetflowFlows.ps1
@@ -14,7 +14,7 @@ Function Get-LMDeviceNetflowFlows {
 
         [Datetime]$EndDate,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceNetflowPorts.ps1
+++ b/Public/Get-LMDeviceNetflowPorts.ps1
@@ -14,7 +14,7 @@ Function Get-LMDeviceNetflowPorts {
 
         [Datetime]$EndDate,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceProperty.ps1
+++ b/Public/Get-LMDeviceProperty.ps1
@@ -15,7 +15,7 @@ Function Get-LMDeviceProperty {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -42,10 +42,10 @@ Function Get-LMDeviceProperty {
         }
         
         #Build header and uri
-        If($PropertyName){
+        If ($PropertyName) {
             $ResourcePath = "/device/devices/$Id/properties/$PropertyName"
         }
-        Else{
+        Else {
             $ResourcePath = "/device/devices/$Id/properties"
         }
 

--- a/Public/Get-LMDeviceSDT.ps1
+++ b/Public/Get-LMDeviceSDT.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceSDT {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMDeviceSDTHistory.ps1
+++ b/Public/Get-LMDeviceSDTHistory.ps1
@@ -10,7 +10,7 @@ Function Get-LMDeviceSDTHistory {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMEscalationChain.ps1
+++ b/Public/Get-LMEscalationChain.ps1
@@ -11,7 +11,7 @@ Function Get-LMEscalationChain {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMEventSource.ps1
+++ b/Public/Get-LMEventSource.ps1
@@ -11,7 +11,7 @@ Function Get-LMEventSource {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMIntegrationLogs.ps1
+++ b/Public/Get-LMIntegrationLogs.ps1
@@ -90,7 +90,7 @@ Function Get-LMIntegrationLogs {
                         $Done = $true
                         Write-LMHost "[WARN]: Reached $QueryLimit record query limitation for this endpoint" -ForegroundColor Yellow
                     }
-                    ElseIf ($Count -ge $Total -and $Total -ge 0) {
+                    Elseif ($Count -ge $Total -and $Total -ge 0) {
                         $Done = $true
                     }
                 }

--- a/Public/Get-LMIntegrationLogs.ps1
+++ b/Public/Get-LMIntegrationLogs.ps1
@@ -17,7 +17,7 @@ Function Get-LMIntegrationLogs {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds
@@ -35,7 +35,7 @@ Function Get-LMIntegrationLogs {
 
         #Convert to epoch, if not set use defaults
         If (!$StartDate) {
-            If($PSCmdlet.ParameterSetName -ne "Id"){
+            If ($PSCmdlet.ParameterSetName -ne "Id") {
                 Write-LMHost "[WARN]: No start date specified, defaulting to last 30 days" -ForegroundColor Yellow
             }
             [int]$StartDate = ([DateTimeOffset]$(Get-Date).AddDays(-30)).ToUnixTimeSeconds()

--- a/Public/Get-LMNetscan.ps1
+++ b/Public/Get-LMNetscan.ps1
@@ -11,7 +11,7 @@ Function Get-LMNetscan {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMNetscanExecution.ps1
+++ b/Public/Get-LMNetscanExecution.ps1
@@ -2,15 +2,15 @@ Function Get-LMNetscanExecution {
 
     [CmdletBinding(DefaultParameterSetName = 'Id')]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'Id')]
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
         [Int]$Id,
 
-        [Parameter(Mandatory,ParameterSetName = 'Name')]
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
         [String]$Name,
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMNetscanExecutionDevices.ps1
+++ b/Public/Get-LMNetscanExecutionDevices.ps1
@@ -2,18 +2,18 @@ Function Get-LMNetscanExecutionDevices {
 
     [CmdletBinding(DefaultParameterSetName = 'Id')]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'Id')]
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
         [Int]$Id,
 
-        [Parameter(Mandatory,ParameterSetName = 'Id')]
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
         [String]$NspId,
 
-        [Parameter(Mandatory,ParameterSetName = 'Name')]
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
         [String]$NspName,
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMNetscanGroup.ps1
+++ b/Public/Get-LMNetscanGroup.ps1
@@ -11,7 +11,7 @@ Function Get-LMNetscanGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMOpsNote.ps1
+++ b/Public/Get-LMOpsNote.ps1
@@ -11,7 +11,7 @@ Function Get-LMOpsNote {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMPortalInfo.ps1
+++ b/Public/Get-LMPortalInfo.ps1
@@ -15,7 +15,7 @@ Function Get-LMPortalInfo {
                 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
         }
         Catch [Exception] {

--- a/Public/Get-LMPropertySource.ps1
+++ b/Public/Get-LMPropertySource.ps1
@@ -11,7 +11,7 @@ Function Get-LMPropertySource {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMRecipientGroup.ps1
+++ b/Public/Get-LMRecipientGroup.ps1
@@ -11,7 +11,7 @@ Function Get-LMRecipientGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMReport.ps1
+++ b/Public/Get-LMReport.ps1
@@ -11,7 +11,7 @@ Function Get-LMReport {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMReportGroup.ps1
+++ b/Public/Get-LMReportGroup.ps1
@@ -11,7 +11,7 @@ Function Get-LMReportGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMRepositoryLogicModules.ps1
+++ b/Public/Get-LMRepositoryLogicModules.ps1
@@ -32,7 +32,7 @@ Function Get-LMRepositoryLogicModules {
                 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
             $Results = $Response.Items
         }

--- a/Public/Get-LMRole.ps1
+++ b/Public/Get-LMRole.ps1
@@ -11,7 +11,7 @@ Function Get-LMRole {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMSDT.ps1
+++ b/Public/Get-LMSDT.ps1
@@ -11,7 +11,7 @@ Function Get-LMSDT {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMTopologyMap.ps1
+++ b/Public/Get-LMTopologyMap.ps1
@@ -11,7 +11,7 @@ Function Get-LMTopologyMap {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMTopologySource.ps1
+++ b/Public/Get-LMTopologySource.ps1
@@ -11,7 +11,7 @@ Function Get-LMTopologySource {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMUnmonitoredDevice.ps1
+++ b/Public/Get-LMUnmonitoredDevice.ps1
@@ -5,7 +5,7 @@ Function Get-LMUnmonitoredDevice {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMUsageMetrics.ps1
+++ b/Public/Get-LMUsageMetrics.ps1
@@ -16,7 +16,7 @@ Function Get-LMUsageMetrics {
                 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
 
             Return $Response

--- a/Public/Get-LMUser.ps1
+++ b/Public/Get-LMUser.ps1
@@ -11,7 +11,7 @@ Function Get-LMUser {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMUserGroup.ps1
+++ b/Public/Get-LMUserGroup.ps1
@@ -11,7 +11,7 @@ Function Get-LMUserGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsite.ps1
+++ b/Public/Get-LMWebsite.ps1
@@ -57,7 +57,7 @@ Function Get-LMWebsite {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteAlerts.ps1
+++ b/Public/Get-LMWebsiteAlerts.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteAlerts {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteCheckpoint.ps1
+++ b/Public/Get-LMWebsiteCheckpoint.ps1
@@ -6,7 +6,7 @@ Function Get-LMWebsiteCheckpoint {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteData.ps1
+++ b/Public/Get-LMWebsiteData.ps1
@@ -61,7 +61,7 @@ Function Get-LMWebsiteData {
                 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
             Return $Response
         

--- a/Public/Get-LMWebsiteGroup.ps1
+++ b/Public/Get-LMWebsiteGroup.ps1
@@ -11,7 +11,7 @@ Function Get-LMWebsiteGroup {
         [Parameter(ParameterSetName = 'Filter')]
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteGroupAlerts.ps1
+++ b/Public/Get-LMWebsiteGroupAlerts.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteGroupAlerts {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteGroupSDT.ps1
+++ b/Public/Get-LMWebsiteGroupSDT.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteGroupSDT {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteGroupSDTHistory.ps1
+++ b/Public/Get-LMWebsiteGroupSDTHistory.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteGroupSDTHistory {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteProperty.ps1
+++ b/Public/Get-LMWebsiteProperty.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteProperty {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteSDT.ps1
+++ b/Public/Get-LMWebsiteSDT.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteSDT {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Get-LMWebsiteSDTHistory.ps1
+++ b/Public/Get-LMWebsiteSDTHistory.ps1
@@ -10,7 +10,7 @@ Function Get-LMWebsiteSDTHistory {
 
         [Object]$Filter,
 
-        [ValidateRange(1,1000)]
+        [ValidateRange(1, 1000)]
         [Int]$BatchSize = 1000
     )
     #Check if we are logged in and have valid api creds

--- a/Public/Import-LMExchangeModule.ps1
+++ b/Public/Import-LMExchangeModule.ps1
@@ -28,7 +28,7 @@ Function Import-LMExchangeModule {
             $ResourcePath = "/exchange/integrations/import"
 
             #Construct payload
-            $Data = @{items = @()}
+            $Data = @{items = @() }
             $Data.items += [PSCustomObject]@{
                 id = $LMExchangeId
             }

--- a/Public/Import-LMLogicModule.ps1
+++ b/Public/Import-LMLogicModule.ps1
@@ -31,10 +31,10 @@ This function requires PowerShell version 6.1 or higher to run.
 Function Import-LMLogicModule {
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'FilePath')]
+        [Parameter(Mandatory, ParameterSetName = 'FilePath')]
         [String]$FilePath,
 
-        [Parameter(Mandatory,ParameterSetName = 'File')]
+        [Parameter(Mandatory, ParameterSetName = 'File')]
         [Object]$File,
         
         [ValidateSet("datasource", "propertyrules", "eventsource", "topologysource", "configsource")]
@@ -49,7 +49,7 @@ Function Import-LMLogicModule {
         If ($Script:LMAuth.Valid) {
             
             #Get file content from path if not given file data directly
-            If($FilePath){
+            If ($FilePath) {
 
                 #Check for PS version 6.1 +
                 If (($PSVersionTable.PSVersion.Major -le 5) -or ($PSVersionTable.PSVersion.Major -eq 6 -and $PSVersionTable.PSVersion.Minor -lt 1)) {
@@ -76,7 +76,7 @@ Function Import-LMLogicModule {
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $File
                 $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath + $QueryParams
 
-                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation  -Payload $FilePath
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $FilePath
 
                 #Issue request
                 $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Form @{file = $File }

--- a/Public/Import-LMRepositoryLogicModules.ps1
+++ b/Public/Import-LMRepositoryLogicModules.ps1
@@ -58,7 +58,7 @@ Function Import-LMRepositoryLogicModules {
 
                 #Issue request
                 $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
-
+                
                 Return "Modules imported successfully: $LogicModuleNames"
             }
             Catch [Exception] {

--- a/Public/Import-LMRepositoryLogicModules.ps1
+++ b/Public/Import-LMRepositoryLogicModules.ps1
@@ -25,13 +25,13 @@ Function Import-LMRepositoryLogicModules {
         [ValidateSet("datasources", "propertyrules", "eventsources", "topologysources", "configsources")]
         [String]$Type,
 
-        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('Name')]
         [String[]]$LogicModuleNames
 
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
                 
@@ -73,5 +73,5 @@ Function Import-LMRepositoryLogicModules {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Invoke-LMActiveDiscovery.ps1
+++ b/Public/Invoke-LMActiveDiscovery.ps1
@@ -107,7 +107,7 @@ Function Invoke-LMActiveDiscovery {
 
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     Write-Host "Scheduled Active Discovery task for device id: $device."

--- a/Public/Invoke-LMActiveDiscovery.ps1
+++ b/Public/Invoke-LMActiveDiscovery.ps1
@@ -69,7 +69,7 @@ Function Invoke-LMActiveDiscovery {
                 }
                 $deviceList = $LookupResult
             }
-            ElseIf ($Id) {
+            Elseif ($Id) {
                 $deviceList = $Id
             }
 
@@ -85,7 +85,7 @@ Function Invoke-LMActiveDiscovery {
                     return
                 }
             }
-            ElseIf ($GroupId) {
+            Elseif ($GroupId) {
                 $deviceList = (Get-LMDeviceGroupDevices -Id $GroupId).Id
                 If (!$deviceList) {
                     Write-Error "Unable to find devices for groupId: $GroupId, please check spelling and try again." 

--- a/Public/Invoke-LMCloudGroupNetScan.ps1
+++ b/Public/Invoke-LMCloudGroupNetScan.ps1
@@ -46,11 +46,11 @@ Function Invoke-LMCloudGroupNetScan {
                 }
                 $Id = $LookupResult
             }
-            Else{
+            Else {
                 $GroupInfo = Get-LMDeviceGroup -Id $Id
             }
 
-            If($GroupInfo.groupType -notlike "*AWS*" -and $GroupInfo.groupType -notlike "*Azure*" -and $GroupInfo.groupType -notlike "*GCP*"){
+            If ($GroupInfo.groupType -notlike "*AWS*" -and $GroupInfo.groupType -notlike "*Azure*" -and $GroupInfo.groupType -notlike "*GCP*") {
                 Write-Error "Specified group: $($GroupInfo.Name) is not of type AWs/Azure/GCP. Please ensure the specified group is a Cloud group and try again."
             }
                 

--- a/Public/Invoke-LMCollectorDebugCommand.ps1
+++ b/Public/Invoke-LMCollectorDebugCommand.ps1
@@ -81,8 +81,8 @@ Function Invoke-LMCollectorDebugCommand {
     Process {
         If ($Script:LMAuth.Valid) {
 
-#Cannot indent or it breaks here-string format
-$DefaultGroovy =@"
+            #Cannot indent or it breaks here-string format
+            $DefaultGroovy = @"
 !groovy 
 import com.santaba.agent.collector3.CollectorDb;
 def hostProps = [:];
@@ -98,8 +98,8 @@ catch(Exception e) {
 $GroovyCommand
 "@
 
-#Cannot indent or it breaks here-string format
-$DefaultPosh =@"
+            #Cannot indent or it breaks here-string format
+            $DefaultPosh = @"
 !posh 
 
 $PoshCommand

--- a/Public/Invoke-LMCollectorDebugCommand.ps1
+++ b/Public/Invoke-LMCollectorDebugCommand.ps1
@@ -87,7 +87,7 @@ Function Invoke-LMCollectorDebugCommand {
 import com.santaba.agent.collector3.CollectorDb;
 def hostProps = [:];
 def instanceProps = [:];
-try {
+Try {
     hostProps = CollectorDb.getInstance().getHost("$CommandHostName").getProperties();
     instanceProps["wildvalue"] = "$CommandWildValue";
     }

--- a/Public/New-LMAPIToken.ps1
+++ b/Public/New-LMAPIToken.ps1
@@ -59,7 +59,7 @@ Function New-LMAPIToken {
         }
         
         #Build header and uri
-        If($Type -eq "Bearer"){
+        If ($Type -eq "Bearer") {
             $Params = "?type=bearer"
         }
 
@@ -78,7 +78,7 @@ Function New-LMAPIToken {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.APIToken" )

--- a/Public/New-LMAPIUser.ps1
+++ b/Public/New-LMAPIUser.ps1
@@ -95,7 +95,7 @@ Function New-LMAPIUser {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMAccessGroup.ps1
+++ b/Public/New-LMAccessGroup.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+Creates a new LogicMonitor access group.
+
+.DESCRIPTION
+The New-LMAccessGroup function is used to create a new access group in LogicMonitor. An access group is a collection of users with similar permissions and access rights for managing modules in the LM exchange and my module toolbox.
+
+.PARAMETER Name
+The name of the access group. This parameter is mandatory.
+
+.PARAMETER Description
+The description of the access group.
+
+.PARAMETER Tenant
+The ID of the tenant to which the access group belongs.
+
+.EXAMPLE
+New-LMAccessGroup -Name "Group1" -Description "Access group for administrators" -Tenant "12345"
+
+This example creates a new access group named "Group1" with the description "Access group for administrators" and assigns it to the tenant with ID "12345".
+
+.NOTES
+For this function to work, you need to be logged in and have valid API credentials. Use the Connect-LMAccount function to log in before running any commands.
+#>
+Function New-LMAccessGroup {
+
+    [CmdletBinding()]
+    Param (
+
+        [Parameter(Mandatory)]
+        [String]$Name,
+
+        [String]$Description,
+
+        [String]$Tenant
+
+    )
+    #Check if we are logged in and have valid api creds
+    Begin {}
+    Process {
+        If ($Script:LMAuth.Valid) {
+                    
+            #Build header and uri
+            $ResourcePath = "/setting/accessgroup/add"
+
+            Try {
+                $Data = @{
+                    description                         = $Description
+                    name                                = $Name
+                    tenantId                            = $Tenant
+                }
+
+                #Remove empty keys so we dont overwrite them
+                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            
+                $Data = ($Data | ConvertTo-Json)
+                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data
+                $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                #Issue request
+                $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.AccessGroup" )
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {}
+}

--- a/Public/New-LMAlertAck.ps1
+++ b/Public/New-LMAlertAck.ps1
@@ -28,8 +28,8 @@ Function New-LMAlertAck {
         [Parameter(Mandatory)]
         [String]$Note
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
             
@@ -39,8 +39,8 @@ Function New-LMAlertAck {
             Try {
 
                 $Data = @{
-                    alertIds = $Ids
-                    ackComment  = $Note
+                    alertIds   = $Ids
+                    ackComment = $Note
                 }
 
                 $Data = ($Data | ConvertTo-Json)
@@ -53,7 +53,7 @@ Function New-LMAlertAck {
                 #Issue request
                 $Response = Invoke-WebRequest -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
-                If($Response.StatusCode -eq 200){
+                If ($Response.StatusCode -eq 200) {
                     Return "Successfully acknowledged alert id(s): $Ids"
                 }
             }
@@ -68,5 +68,5 @@ Function New-LMAlertAck {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/New-LMAlertEscalation.ps1
+++ b/Public/New-LMAlertEscalation.ps1
@@ -20,8 +20,8 @@ Function New-LMAlertEscalation {
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [String]$Id
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
             
@@ -38,7 +38,7 @@ Function New-LMAlertEscalation {
                 #Issue request
                 $Response = Invoke-WebRequest -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1]
 
-                If($Response.StatusCode -eq 200){
+                If ($Response.StatusCode -eq 200) {
                     Return "Successfully escalated alert id: $Id"
                 }
             }
@@ -53,5 +53,5 @@ Function New-LMAlertEscalation {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/New-LMAlertNote.ps1
+++ b/Public/New-LMAlertNote.ps1
@@ -32,8 +32,8 @@ Function New-LMAlertNote {
         [Parameter(Mandatory)]
         [String]$Note
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
             
@@ -44,7 +44,7 @@ Function New-LMAlertNote {
     
                 $Data = @{
                     alertIds = $Ids
-                    note  = $Note
+                    note     = $Note
                 }
     
                 $Data = ($Data | ConvertTo-Json)
@@ -57,7 +57,7 @@ Function New-LMAlertNote {
                 #Issue request
                 $Response = Invoke-WebRequest -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
     
-                If($Response.StatusCode -eq 200){
+                If ($Response.StatusCode -eq 200) {
                     Return "Successfully updated note for alert id(s): $Ids"
                 }
             }
@@ -72,5 +72,5 @@ Function New-LMAlertNote {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/New-LMAppliesToFunction.ps1
+++ b/Public/New-LMAppliesToFunction.ps1
@@ -41,9 +41,9 @@ Function New-LMAppliesToFunction {
 
         Try {
             $Data = @{
-                name                                = $Name
-                description                         = $Description
-                code                                = $AppliesTo
+                name        = $Name
+                description = $Description
+                code        = $AppliesTo
             }
 
             $Data = ($Data | ConvertTo-Json)
@@ -53,7 +53,7 @@ Function New-LMAppliesToFunction {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMCachedAccount.ps1
+++ b/Public/New-LMCachedAccount.ps1
@@ -19,19 +19,19 @@ New-LMCachedAccount -AccessId xxxxxx -AccessKey xxxxxx -AccountName subdomain
 #>
 Function New-LMCachedAccount {
 
-    [CmdletBinding(DefaultParameterSetName="LMv1")]
+    [CmdletBinding(DefaultParameterSetName = "LMv1")]
     Param (
-        [Parameter(Mandatory, ParameterSetName="LMv1")]
+        [Parameter(Mandatory, ParameterSetName = "LMv1")]
         [String]$AccessId,
 
-        [Parameter(Mandatory, ParameterSetName="LMv1")]
+        [Parameter(Mandatory, ParameterSetName = "LMv1")]
         [String]$AccessKey,
 
-        [Parameter(Mandatory, ParameterSetName="LMv1")]
-        [Parameter(Mandatory, ParameterSetName="Bearer")]
+        [Parameter(Mandatory, ParameterSetName = "LMv1")]
+        [Parameter(Mandatory, ParameterSetName = "Bearer")]
         [String]$AccountName,
 
-        [Parameter(Mandatory, ParameterSetName="Bearer")]
+        [Parameter(Mandatory, ParameterSetName = "Bearer")]
         [String]$BearerToken,
 
         [String]$CachedAccountName = $AccountName,
@@ -44,7 +44,7 @@ Function New-LMCachedAccount {
         Write-Host "[INFO]: Existing vault Logic.Monitor already exists, skipping creation"
     }
     Catch {
-        If($_.Exception.Message -like "*There are currently no extension vaults registered*") {
+        If ($_.Exception.Message -like "*There are currently no extension vaults registered*") {
             Write-Host "[INFO]: Credential vault for cached accounts does not currently exist, creating credential vault: Logic.Monitor"
             Register-SecretVault -Name Logic.Monitor -ModuleName Microsoft.PowerShell.SecretStore
             Get-SecretStoreConfiguration | Out-Null
@@ -53,29 +53,29 @@ Function New-LMCachedAccount {
 
     $CurrentDate = Get-Date
     #Convert to secure string
-    If($BearerToken){
+    If ($BearerToken) {
         $Secret = $BearerToken | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
         [Hashtable]$Metadata = @{
-            Portal      = [String]$AccountName
-            Id          = "$($BearerToken.Substring(0,20))****"
-            Modified    = [DateTime]$CurrentDate
-            Type    = "Bearer"
+            Portal   = [String]$AccountName
+            Id       = "$($BearerToken.Substring(0,20))****"
+            Modified = [DateTime]$CurrentDate
+            Type     = "Bearer"
         }
     }
-    Else{
+    Else {
         $Secret = $AccessKey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
         [Hashtable]$Metadata = @{
-            Portal      = [String]$AccountName
-            Id          = [String]$AccessId
-            Modified    = [DateTime]$CurrentDate
-            Type    = "LMv1"
+            Portal   = [String]$AccountName
+            Id       = [String]$AccessId
+            Modified = [DateTime]$CurrentDate
+            Type     = "LMv1"
         }
     }
-    Try{
+    Try {
         Set-Secret -Name $CachedAccountName -Secret $Secret -Vault Logic.Monitor -Metadata $Metadata -NoClobber:$(!$OverwriteExisting)
         Write-Host "[INFO]: Successfully created cached account ($CachedAccountName) secret for portal: $AccountName"
     }
-    Catch{
+    Catch {
         Write-Error $_.Exception.Message
     }
 

--- a/Public/New-LMCollector.ps1
+++ b/Public/New-LMCollector.ps1
@@ -107,7 +107,7 @@ Function New-LMCollector {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMCollectorGroup.ps1
+++ b/Public/New-LMCollectorGroup.ps1
@@ -63,11 +63,11 @@ Function New-LMCollectorGroup {
 
             Try {
                 $Data = @{
-                    description                         = $Description
-                    name                                = $Name
-                    autoBalance                         = $AutoBalance
-                    customProperties                    = $customProperties
-                    autoBalanceInstanceCountThreshold   = $AutoBalanceInstanceCountThreshold
+                    description                       = $Description
+                    name                              = $Name
+                    autoBalance                       = $AutoBalance
+                    customProperties                  = $customProperties
+                    autoBalanceInstanceCountThreshold = $AutoBalanceInstanceCountThreshold
                 }
 
             

--- a/Public/New-LMCollectorGroup.ps1
+++ b/Public/New-LMCollectorGroup.ps1
@@ -72,7 +72,7 @@ Function New-LMCollectorGroup {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMDashboardGroup.ps1
+++ b/Public/New-LMDashboardGroup.ps1
@@ -79,10 +79,10 @@ Function New-LMDashboardGroup {
 
         Try {
             $Data = @{
-                name                                = $Name
-                description                         = $Description
-                parentId                            = $ParentGroupId
-                widgetTokens                        = $WidgetTokensArray
+                name         = $Name
+                description  = $Description
+                parentId     = $ParentGroupId
+                widgetTokens = $WidgetTokensArray
             }
 
             $Data = ($Data | ConvertTo-Json)
@@ -92,7 +92,7 @@ Function New-LMDashboardGroup {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDatasourceGraph.ps1
+++ b/Public/New-LMDatasourceGraph.ps1
@@ -38,7 +38,7 @@ Function New-LMDatasourceGraph {
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If($DataSourceName){
+        If ($DataSourceName) {
             $LookupResult = (Get-LMDatasource -Name $DataSourceName).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DataSourceName) {
                 Return

--- a/Public/New-LMDatasourceOverviewGraph.ps1
+++ b/Public/New-LMDatasourceOverviewGraph.ps1
@@ -27,17 +27,17 @@ Function New-LMDatasourceOverviewGraph {
         [Parameter(Mandatory)]
         $RawObject,
 
-        [Parameter(Mandatory,ParameterSetName = 'dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'dsId')]
         $DatasourceId,
 
-        [Parameter(Mandatory,ParameterSetName = 'dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'dsName')]
         $DatasourceName
 
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If($DataSourceName){
+        If ($DataSourceName) {
             $LookupResult = (Get-LMDatasource -Name $DataSourceName).Id
             If (Test-LookupResult -Result $LookupResult -LookupString $DataSourceName) {
                 Return
@@ -56,7 +56,7 @@ Function New-LMDatasourceOverviewGraph {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.DatasourceGraph" )

--- a/Public/New-LMDevice.ps1
+++ b/Public/New-LMDevice.ps1
@@ -119,22 +119,22 @@ Function New-LMDevice {
 
             Try {
                 $Data = @{
-                    name                      = $Name
-                    displayName               = $DisplayName
-                    description               = $Description
-                    disableAlerting           = $DisableAlerting
-                    enableNetflow             = $EnableNetFlow
-                    customProperties          = $customProperties
-                    deviceType                = $DeviceType
-                    preferredCollectorId      = $PreferredCollectorId
-                    preferredCollectorGroupId = $PreferredCollectorGroupId
+                    name                         = $Name
+                    displayName                  = $DisplayName
+                    description                  = $Description
+                    disableAlerting              = $DisableAlerting
+                    enableNetflow                = $EnableNetFlow
+                    customProperties             = $customProperties
+                    deviceType                   = $DeviceType
+                    preferredCollectorId         = $PreferredCollectorId
+                    preferredCollectorGroupId    = $PreferredCollectorGroupId
                     autoBalancedCollectorGroupId = $AutoBalancedCollectorGroupId
-                    link                      = $Link
-                    netflowCollectorGroupId   = $NetflowCollectorGroupId
-                    netflowCollectorId        = $NetflowCollectorId
-                    logCollectorGroupId       = $LogCollectorGroupId
-                    logCollectorId            = $LogCollectorId
-                    hostGroupIds              = $HostGroupIds -join ","
+                    link                         = $Link
+                    netflowCollectorGroupId      = $NetflowCollectorGroupId
+                    netflowCollectorId           = $NetflowCollectorId
+                    logCollectorGroupId          = $LogCollectorGroupId
+                    logCollectorId               = $LogCollectorId
+                    hostGroupIds                 = $HostGroupIds -join ","
                 }
 
             

--- a/Public/New-LMDevice.ps1
+++ b/Public/New-LMDevice.ps1
@@ -139,7 +139,7 @@ Function New-LMDevice {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMDeviceDatasourceInstance.ps1
+++ b/Public/New-LMDeviceDatasourceInstance.ps1
@@ -152,7 +152,7 @@ Function New-LMDeviceDatasourceInstance {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceDatasourceInstance.ps1
+++ b/Public/New-LMDeviceDatasourceInstance.ps1
@@ -143,7 +143,7 @@ Function New-LMDeviceDatasourceInstance {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMDeviceDatasourceInstance.ps1
+++ b/Public/New-LMDeviceDatasourceInstance.ps1
@@ -81,10 +81,12 @@ Function New-LMDeviceDatasourceInstance {
     
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Alias('DeviceId')]
         [Int]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Alias('DeviceName')]
         [String]$Name
 
     )

--- a/Public/New-LMDeviceDatasourceInstanceGroup.ps1
+++ b/Public/New-LMDeviceDatasourceInstanceGroup.ps1
@@ -51,10 +51,12 @@ Function New-LMDeviceDatasourceInstanceGroup {
     
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Alias('DeviceId')]
         [Int]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Alias('DeviceName')]
         [String]$Name
 
     )

--- a/Public/New-LMDeviceDatasourceInstanceGroup.ps1
+++ b/Public/New-LMDeviceDatasourceInstanceGroup.ps1
@@ -106,7 +106,7 @@ Function New-LMDeviceDatasourceInstanceGroup {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceDatasourceInstanceGroup.ps1
+++ b/Public/New-LMDeviceDatasourceInstanceGroup.ps1
@@ -97,7 +97,7 @@ Function New-LMDeviceDatasourceInstanceGroup {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
             
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMDeviceDatasourceInstanceSDT.ps1
+++ b/Public/New-LMDeviceDatasourceInstanceSDT.ps1
@@ -87,11 +87,11 @@ Function New-LMDeviceDatasourceInstanceSDT {
 
         [Parameter(Mandatory, ParameterSetName = 'Weekly')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek')]
-        [ValidateSet("Monday", "Tuesday", "Wednesday","Thursday","Friday","Saturday","Sunday")]
+        [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
         [String]$WeekDay,
 
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek')]
-        [ValidateSet("First", "Second", "Third","Fourth","Last")]
+        [ValidateSet("First", "Second", "Third", "Fourth", "Last")]
         [String]$WeekOfMonth,
 
         [Parameter(Mandatory, ParameterSetName = 'Monthly')]
@@ -108,27 +108,27 @@ Function New-LMDeviceDatasourceInstanceSDT {
         #Build header and uri
         $ResourcePath = "/sdt/sdts"
 
-        Switch -Wildcard ($PSCmdlet.ParameterSetName){
-            "OneTime*" {$Occurance = "oneTime"}
-            "Daily*" {$Occurance = "daily"}
-            "Monthly*" {$Occurance = "monthly"}
-            "MonthlyByWeek*" {$Occurance = "monthlyByWeek"}
-            "Weekly*" {$Occurance = "weekly"}
+        Switch -Wildcard ($PSCmdlet.ParameterSetName) {
+            "OneTime*" { $Occurance = "oneTime" }
+            "Daily*" { $Occurance = "daily" }
+            "Monthly*" { $Occurance = "monthly" }
+            "MonthlyByWeek*" { $Occurance = "monthlyByWeek" }
+            "Weekly*" { $Occurance = "weekly" }
         }
 
         Try {
             $Data = $null
 
             $Data = @{
-                comment                 = $Comment
-                dataSourceInstanceId    = $DeviceDataSourceInstanceId
-                sdtType                 = $Occurance
+                comment              = $Comment
+                dataSourceInstanceId = $DeviceDataSourceInstanceId
+                sdtType              = $Occurance
                 #timezone                = $Timezone
-                type                    = "DeviceDataSourceInstanceSDT"
+                type                 = "DeviceDataSourceInstanceSDT"
             }
 
-            Switch ($Occurance){
-               "onetime" {
+            Switch ($Occurance) {
+                "onetime" {
                     #Get UTC time based on selected timezone
                     # $TimeZoneID = [System.TimeZoneInfo]::FindSystemTimeZoneById($Timezone)
                     # $StartUTCTime = [System.TimeZoneInfo]::ConvertTimeFromUtc($StartDate.ToUniversalTime(), $TimeZoneID)
@@ -139,43 +139,43 @@ Function New-LMDeviceDatasourceInstanceSDT {
 
                     $StartDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $StartDate.ToUniversalTime()).TotalMilliseconds
                     $EndDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $EndDate.ToUniversalTime()).TotalMilliseconds
-                    $Data.Add('endDateTime',[math]::Round($EndDateTime))
-                    $Data.Add('startDateTime',[math]::Round($StartDateTime))
-               }
+                    $Data.Add('endDateTime', [math]::Round($EndDateTime))
+                    $Data.Add('startDateTime', [math]::Round($StartDateTime))
+                }
 
-               "daily" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-               } 
+                "daily" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                } 
                
-               "weekly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-               } 
+                "weekly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                } 
                
-               "monthly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('monthDay',$DayOfMonth)
-               } 
+                "monthly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('monthDay', $DayOfMonth)
+                } 
                
-               "monthlyByWeek" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-                    $Data.Add('weekOfMonth',$WeekOfMonth)
-               } 
+                "monthlyByWeek" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                    $Data.Add('weekOfMonth', $WeekOfMonth)
+                } 
 
-               default {}
+                default {}
             }
 
             #Remove empty keys so we dont overwrite them
@@ -188,7 +188,7 @@ Function New-LMDeviceDatasourceInstanceSDT {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceDatasourceInstanceSDT.ps1
+++ b/Public/New-LMDeviceDatasourceInstanceSDT.ps1
@@ -179,7 +179,7 @@ Function New-LMDeviceDatasourceInstanceSDT {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMDeviceDatasourceSDT.ps1
+++ b/Public/New-LMDeviceDatasourceSDT.ps1
@@ -174,7 +174,7 @@ Function New-LMDeviceDatasourceSDT {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMDeviceDatasourceSDT.ps1
+++ b/Public/New-LMDeviceDatasourceSDT.ps1
@@ -82,11 +82,11 @@ Function New-LMDeviceDatasourceSDT {
 
         [Parameter(Mandatory, ParameterSetName = 'Weekly')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek')]
-        [ValidateSet("Monday", "Tuesday", "Wednesday","Thursday","Friday","Saturday","Sunday")]
+        [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
         [String]$WeekDay,
 
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek')]
-        [ValidateSet("First", "Second", "Third","Fourth","Last")]
+        [ValidateSet("First", "Second", "Third", "Fourth", "Last")]
         [String]$WeekOfMonth,
 
         [Parameter(Mandatory, ParameterSetName = 'Monthly')]
@@ -103,27 +103,27 @@ Function New-LMDeviceDatasourceSDT {
         #Build header and uri
         $ResourcePath = "/sdt/sdts"
 
-        Switch -Wildcard ($PSCmdlet.ParameterSetName){
-            "OneTime*" {$Occurance = "oneTime"}
-            "Daily*" {$Occurance = "daily"}
-            "Monthly*" {$Occurance = "monthly"}
-            "MonthlyByWeek*" {$Occurance = "monthlyByWeek"}
-            "Weekly*" {$Occurance = "weekly"}
+        Switch -Wildcard ($PSCmdlet.ParameterSetName) {
+            "OneTime*" { $Occurance = "oneTime" }
+            "Daily*" { $Occurance = "daily" }
+            "Monthly*" { $Occurance = "monthly" }
+            "MonthlyByWeek*" { $Occurance = "monthlyByWeek" }
+            "Weekly*" { $Occurance = "weekly" }
         }
 
         Try {
             $Data = $null
 
             $Data = @{
-                comment               = $Comment
-                deviceDataSourceId    = $deviceDataSourceId
-                sdtType               = $Occurance
+                comment            = $Comment
+                deviceDataSourceId = $deviceDataSourceId
+                sdtType            = $Occurance
                 #timezone             = $Timezone
-                type                  = "DeviceDataSourceSDT"
+                type               = "DeviceDataSourceSDT"
             }
 
-            Switch ($Occurance){
-               "onetime" {
+            Switch ($Occurance) {
+                "onetime" {
                     #Get UTC time based on selected timezone
                     # $TimeZoneID = [System.TimeZoneInfo]::FindSystemTimeZoneById($Timezone)
                     # $StartUTCTime = [System.TimeZoneInfo]::ConvertTimeFromUtc($StartDate.ToUniversalTime(), $TimeZoneID)
@@ -134,43 +134,43 @@ Function New-LMDeviceDatasourceSDT {
 
                     $StartDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $StartDate.ToUniversalTime()).TotalMilliseconds
                     $EndDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $EndDate.ToUniversalTime()).TotalMilliseconds
-                    $Data.Add('endDateTime',[math]::Round($EndDateTime))
-                    $Data.Add('startDateTime',[math]::Round($StartDateTime))
-               }
+                    $Data.Add('endDateTime', [math]::Round($EndDateTime))
+                    $Data.Add('startDateTime', [math]::Round($StartDateTime))
+                }
 
-               "daily" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-               } 
+                "daily" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                } 
                
-               "weekly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-               } 
+                "weekly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                } 
                
-               "monthly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('monthDay',$DayOfMonth)
-               } 
+                "monthly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('monthDay', $DayOfMonth)
+                } 
                
-               "monthlyByWeek" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-                    $Data.Add('weekOfMonth',$WeekOfMonth)
-               } 
+                "monthlyByWeek" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                    $Data.Add('weekOfMonth', $WeekOfMonth)
+                } 
 
-               default {}
+                default {}
             }
 
             #Remove empty keys so we dont overwrite them
@@ -183,7 +183,7 @@ Function New-LMDeviceDatasourceSDT {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceGroup.ps1
+++ b/Public/New-LMDeviceGroup.ps1
@@ -113,7 +113,7 @@ Function New-LMDeviceGroup {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.DeviceGroup" )

--- a/Public/New-LMDeviceGroupSDT.ps1
+++ b/Public/New-LMDeviceGroupSDT.ps1
@@ -102,12 +102,12 @@ Function New-LMDeviceGroupSDT {
         [Parameter(Mandatory, ParameterSetName = 'Weekly-DeviceGroupName')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceGroupId')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceGroupName')]
-        [ValidateSet("Monday", "Tuesday", "Wednesday","Thursday","Friday","Saturday","Sunday")]
+        [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
         [String]$WeekDay,
 
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceGroupId')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceGroupName')]
-        [ValidateSet("First", "Second", "Third","Fourth","Last")]
+        [ValidateSet("First", "Second", "Third", "Fourth", "Last")]
         [String]$WeekOfMonth,
 
         [Parameter(Mandatory, ParameterSetName = 'Monthly-DeviceGroupId')]
@@ -146,12 +146,12 @@ Function New-LMDeviceGroupSDT {
             $DeviceGroupId = $LookupResult
         }
 
-        Switch -Wildcard ($PSCmdlet.ParameterSetName){
-            "OneTime-Device*" {$Occurance = "oneTime"}
-            "Daily-Device*" {$Occurance = "daily"}
-            "Monthly-Device*" {$Occurance = "monthly"}
-            "MonthlyByWeek-Device*" {$Occurance = "monthlyByWeek"}
-            "Weekly-Device*" {$Occurance = "weekly"}
+        Switch -Wildcard ($PSCmdlet.ParameterSetName) {
+            "OneTime-Device*" { $Occurance = "oneTime" }
+            "Daily-Device*" { $Occurance = "daily" }
+            "Monthly-Device*" { $Occurance = "monthly" }
+            "MonthlyByWeek-Device*" { $Occurance = "monthlyByWeek" }
+            "Weekly-Device*" { $Occurance = "weekly" }
         }
 
         #Build header and uri
@@ -161,15 +161,15 @@ Function New-LMDeviceGroupSDT {
             $Data = $null
 
             $Data = @{
-                comment         = $Comment
-                deviceGroupId        = $DeviceGroupId
-                sdtType         = $Occurance
+                comment       = $Comment
+                deviceGroupId = $DeviceGroupId
+                sdtType       = $Occurance
                 #timezone        = $Timezone
-                type            = "ResourceGroupSDT"
+                type          = "ResourceGroupSDT"
             }
 
-            Switch ($Occurance){
-               "onetime" {
+            Switch ($Occurance) {
+                "onetime" {
                     #Get UTC time based on selected timezone
                     # $TimeZoneID = [System.TimeZoneInfo]::FindSystemTimeZoneById($Timezone)
                     # $StartUTCTime = [System.TimeZoneInfo]::ConvertTimeFromUtc($StartDate.ToUniversalTime(), $TimeZoneID)
@@ -180,43 +180,43 @@ Function New-LMDeviceGroupSDT {
 
                     $StartDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $StartDate.ToUniversalTime()).TotalMilliseconds
                     $EndDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $EndDate.ToUniversalTime()).TotalMilliseconds
-                    $Data.Add('endDateTime',[math]::Round($EndDateTime))
-                    $Data.Add('startDateTime',[math]::Round($StartDateTime))
-               }
+                    $Data.Add('endDateTime', [math]::Round($EndDateTime))
+                    $Data.Add('startDateTime', [math]::Round($StartDateTime))
+                }
 
-               "daily" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-               } 
+                "daily" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                } 
                
-               "weekly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-               } 
+                "weekly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                } 
                
-               "monthly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('monthDay',$DayOfMonth)
-               } 
+                "monthly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('monthDay', $DayOfMonth)
+                } 
                
-               "monthlyByWeek" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-                    $Data.Add('weekOfMonth',$WeekOfMonth)
-               } 
+                "monthlyByWeek" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                    $Data.Add('weekOfMonth', $WeekOfMonth)
+                } 
 
-               default {}
+                default {}
             }
 
             #Remove empty keys so we dont overwrite them
@@ -229,7 +229,7 @@ Function New-LMDeviceGroupSDT {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceGroupSDT.ps1
+++ b/Public/New-LMDeviceGroupSDT.ps1
@@ -220,7 +220,7 @@ Function New-LMDeviceGroupSDT {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMDeviceProperty.ps1
+++ b/Public/New-LMDeviceProperty.ps1
@@ -79,7 +79,7 @@ Function New-LMDeviceProperty {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceSDT.ps1
+++ b/Public/New-LMDeviceSDT.ps1
@@ -110,12 +110,12 @@ Function New-LMDeviceSDT {
         [Parameter(Mandatory, ParameterSetName = 'Weekly-DeviceName')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceId')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceName')]
-        [ValidateSet("Monday", "Tuesday", "Wednesday","Thursday","Friday","Saturday","Sunday")]
+        [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
         [String]$WeekDay,
 
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceId')]
         [Parameter(Mandatory, ParameterSetName = 'MonthlyByWeek-DeviceName')]
-        [ValidateSet("First", "Second", "Third","Fourth","Last")]
+        [ValidateSet("First", "Second", "Third", "Fourth", "Last")]
         [String]$WeekOfMonth,
 
         [Parameter(Mandatory, ParameterSetName = 'Monthly-DeviceId')]
@@ -136,12 +136,12 @@ Function New-LMDeviceSDT {
             $DeviceId = $LookupResult
         }
 
-        Switch -Wildcard ($PSCmdlet.ParameterSetName){
-            "OneTime-Device*" {$Occurance = "oneTime"}
-            "Daily-Device*" {$Occurance = "daily"}
-            "Monthly-Device*" {$Occurance = "monthly"}
-            "MonthlyByWeek-Device*" {$Occurance = "monthlyByWeek"}
-            "Weekly-Device*" {$Occurance = "weekly"}
+        Switch -Wildcard ($PSCmdlet.ParameterSetName) {
+            "OneTime-Device*" { $Occurance = "oneTime" }
+            "Daily-Device*" { $Occurance = "daily" }
+            "Monthly-Device*" { $Occurance = "monthly" }
+            "MonthlyByWeek-Device*" { $Occurance = "monthlyByWeek" }
+            "Weekly-Device*" { $Occurance = "weekly" }
         }
 
         #Build header and uri
@@ -151,15 +151,15 @@ Function New-LMDeviceSDT {
             $Data = $null
 
             $Data = @{
-                comment         = $Comment
-                deviceId        = $DeviceId
-                sdtType         = $Occurance
+                comment  = $Comment
+                deviceId = $DeviceId
+                sdtType  = $Occurance
                 #timezone        = $Timezone
-                type            = "ResourceSDT"
+                type     = "ResourceSDT"
             }
 
-            Switch ($Occurance){
-               "onetime" {
+            Switch ($Occurance) {
+                "onetime" {
                     #Get UTC time based on selected timezone
                     # $TimeZoneID = [System.TimeZoneInfo]::FindSystemTimeZoneById($Timezone)
                     # $StartUTCTime = [System.TimeZoneInfo]::ConvertTimeFromUtc((Get-Date $StartDate).ToUniversalTime(), $TimeZoneID)
@@ -171,43 +171,43 @@ Function New-LMDeviceSDT {
 
                     $StartDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $StartDate.ToUniversalTime()).TotalMilliseconds
                     $EndDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $EndDate.ToUniversalTime()).TotalMilliseconds
-                    $Data.Add('endDateTime',[math]::Round($EndDateTime))
-                    $Data.Add('startDateTime',[math]::Round($StartDateTime))
-               }
+                    $Data.Add('endDateTime', [math]::Round($EndDateTime))
+                    $Data.Add('startDateTime', [math]::Round($StartDateTime))
+                }
 
-               "daily" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-               } 
+                "daily" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                } 
                
-               "weekly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-               } 
+                "weekly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                } 
                
-               "monthly" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('monthDay',$DayOfMonth)
-               } 
+                "monthly" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('monthDay', $DayOfMonth)
+                } 
                
-               "monthlyByWeek" {
-                    $Data.Add('hour',$StartHour)
-                    $Data.Add('minute',$StartMinute)
-                    $Data.Add('endHour',$EndHour)
-                    $Data.Add('endMinute',$EndMinute)
-                    $Data.Add('weekDay',$WeekDay)
-                    $Data.Add('weekOfMonth',$WeekOfMonth)
-               } 
+                "monthlyByWeek" {
+                    $Data.Add('hour', $StartHour)
+                    $Data.Add('minute', $StartMinute)
+                    $Data.Add('endHour', $EndHour)
+                    $Data.Add('endMinute', $EndMinute)
+                    $Data.Add('weekDay', $WeekDay)
+                    $Data.Add('weekOfMonth', $WeekOfMonth)
+                } 
 
-               default {}
+                default {}
             }
 
             #Remove empty keys so we dont overwrite them
@@ -220,7 +220,7 @@ Function New-LMDeviceSDT {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMDeviceSDT.ps1
+++ b/Public/New-LMDeviceSDT.ps1
@@ -211,7 +211,7 @@ Function New-LMDeviceSDT {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMEnhancedNetscan.ps1
+++ b/Public/New-LMEnhancedNetscan.ps1
@@ -151,7 +151,7 @@ Function New-LMEnhancedNetScan {
 
                 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
                 $Data = ($Data | ConvertTo-Json -Depth 10)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data
                 $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath

--- a/Public/New-LMEnhancedNetscan.ps1
+++ b/Public/New-LMEnhancedNetscan.ps1
@@ -95,10 +95,10 @@ Function New-LMEnhancedNetScan {
             $ResourcePath = "/setting/netscans"
 
             #Get Netscan GroupID
-            If($NetScanGroupName){
+            If ($NetScanGroupName) {
                 $NetScanGroupId = (Get-LMNetScanGroup -Name $NetScanGroupName).Id
             }
-            Else{
+            Else {
                 $NetScanGroupId = 1
             }
 
@@ -134,19 +134,19 @@ Function New-LMEnhancedNetScan {
 
             Try {
                 $Data = @{
-                    name                      = $Name
-                    collector                 = $CollectorId
-                    description               = $Description
-                    duplicate                 = $Duplicates
-                    method                    = $Method
-                    nextStart                 = $NextStart
-                    groovyScript              = $GroovyScript
-                    nextStartEpoch            = $NextStartEpoch
-                    nsgId                     = $NetScanGroupId
-                    credentials               = $Creds
-                    filters                   = $Filters
-                    schedule                  = $Schedule
-                    scriptType                = "embeded"
+                    name           = $Name
+                    collector      = $CollectorId
+                    description    = $Description
+                    duplicate      = $Duplicates
+                    method         = $Method
+                    nextStart      = $NextStart
+                    groovyScript   = $GroovyScript
+                    nextStartEpoch = $NextStartEpoch
+                    nsgId          = $NetScanGroupId
+                    credentials    = $Creds
+                    filters        = $Filters
+                    schedule       = $Schedule
+                    scriptType     = "embeded"
                 }
 
                 

--- a/Public/New-LMNetscan.ps1
+++ b/Public/New-LMNetscan.ps1
@@ -151,7 +151,7 @@ Function New-LMNetScan {
 
                 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
                 
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMNetscanGroup.ps1
+++ b/Public/New-LMNetscanGroup.ps1
@@ -45,8 +45,8 @@ Function New-LMNetscanGroup {
 
             Try {
                 $Data = @{
-                    description                         = $Description
-                    name                                = $Name
+                    description = $Description
+                    name        = $Name
                 }
 
             

--- a/Public/New-LMNetscanGroup.ps1
+++ b/Public/New-LMNetscanGroup.ps1
@@ -51,7 +51,7 @@ Function New-LMNetscanGroup {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMOpsNote.ps1
+++ b/Public/New-LMOpsNote.ps1
@@ -51,41 +51,41 @@ Function New-LMOpsNote {
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If(!$NoteDate){
+        If (!$NoteDate) {
             [int64]$NoteDate = [DateTimeOffset]::Now.ToUnixTimeSeconds()
         }
-        Else{
+        Else {
             $Epoch = Get-Date -Date "01/01/1970"
             [int64]$NoteDate = (New-TimeSpan -Start $Epoch -End $NoteDate.ToUniversalTime()).TotalSeconds
         }
 
         $Scope = @()
-        If($ResourceIds -or $WebsiteIds -or $DeviceGroupIds){
-            Foreach($id in $DeviceIds){
+        If ($ResourceIds -or $WebsiteIds -or $DeviceGroupIds) {
+            Foreach ($id in $DeviceIds) {
                 $Scope += [PSCustomObject]@{
-                    type = "device"
-                    groupId = "0"
+                    type     = "device"
+                    groupId  = "0"
                     deviceId = $id
                 }
             }
-            Foreach($id in $WebsiteIds){
+            Foreach ($id in $WebsiteIds) {
                 $Scope += [PSCustomObject]@{
-                    type = "website"
-                    groupId = "0"
+                    type      = "website"
+                    groupId   = "0"
                     websiteId = $id
                 }
             }
-            Foreach($id in $DeviceGroupIds){
+            Foreach ($id in $DeviceGroupIds) {
                 $Scope += @{
-                    type = "deviceGroup"
+                    type    = "deviceGroup"
                     groupId = $id
                 }
             }
         }
 
         $TagList = @()
-        Foreach($tag in $Tags){
-            $TagList += @{name = $tag}
+        Foreach ($tag in $Tags) {
+            $TagList += @{name = $tag }
         }
 
 
@@ -110,7 +110,7 @@ Function New-LMOpsNote {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return $Response

--- a/Public/New-LMOpsNote.ps1
+++ b/Public/New-LMOpsNote.ps1
@@ -101,7 +101,7 @@ Function New-LMOpsNote {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMPushMetricDataPoint.ps1
+++ b/Public/New-LMPushMetricDataPoint.ps1
@@ -47,27 +47,27 @@ Function New-LMPushMetricDataPoint {
         [System.Collections.Generic.List[object]]$DataPoints, # object with datapoint name and value
         [ValidateSet("counter", "derive", "gauge")]
         [String]$DataPointType = "gauge",
-        [ValidateSet("min", "max", "avg","sum","none","percentile")]
+        [ValidateSet("min", "max", "avg", "sum", "none", "percentile")]
         [String]$DataPointAggregationType = "none",
         [ValidateRange(0, 100)]
         [Int]$PercentileValue
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
-        If(!$DataPointsArray){
+        If (!$DataPointsArray) {
             $DataPointsArray = [System.Collections.Generic.List[object]]::New()
         }
         
         #Add each datapoint to new datapoint array
-        Foreach($Datapoint in $DataPoints){
+        Foreach ($Datapoint in $DataPoints) {
             $DataPointsArray.Add([PSCustomObject]@{
-                dataPointName               = $Datapoint.Name
-                dataPointType               = $DataPointType
-                dataPointDescription        = ($Datapoint.Description -replace '“|”','')
-                dataPointAggregationType    = $DataPointAggregationType
-                percentileValue             = $PercentileValue
-                values                      = @{$((Get-Date -UFormat %s).Split(".")[0])=$Datapoint.Value}
-            })
+                    dataPointName            = $Datapoint.Name
+                    dataPointType            = $DataPointType
+                    dataPointDescription     = ($Datapoint.Description -replace '“|”', '')
+                    dataPointAggregationType = $DataPointAggregationType
+                    percentileValue          = $PercentileValue
+                    values                   = @{$((Get-Date -UFormat %s).Split(".")[0]) = $Datapoint.Value }
+                })
         }
             
         Return $DataPointsArray

--- a/Public/New-LMPushMetricInstance.ps1
+++ b/Public/New-LMPushMetricInstance.ps1
@@ -36,7 +36,7 @@ Function New-LMPushMetricInstance {
     [CmdletBinding()]
     Param (
         
-    [System.Collections.Generic.List[object]]$InstancesArrary,
+        [System.Collections.Generic.List[object]]$InstancesArrary,
 
         [Parameter(Mandatory)]
         [String]$InstanceName,
@@ -52,18 +52,18 @@ Function New-LMPushMetricInstance {
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
-        If(!$InstancesArrary){
+        If (!$InstancesArrary) {
             $InstancesArrary = [System.Collections.Generic.List[object]]::New()
         }
 
         #Add new instance to new instances array
         $InstancesArrary.Add([PSCustomObject]@{
-            instanceName = $InstanceName
-            instanceDisplayName = If($InstanceDisplayName){$InstanceDisplayName}Else{$InstanceName}
-            instanceProperties = $InstanceProperties
-            instanceDescription = $InstanceDescription
-            dataPoints = $Datapoints
-        })
+                instanceName        = $InstanceName
+                instanceDisplayName = If ($InstanceDisplayName) { $InstanceDisplayName }Else { $InstanceName }
+                instanceProperties  = $InstanceProperties
+                instanceDescription = $InstanceDescription
+                dataPoints          = $Datapoints
+            })
 
         Return $InstancesArrary
     }

--- a/Public/New-LMReportGroup.ps1
+++ b/Public/New-LMReportGroup.ps1
@@ -55,7 +55,7 @@ Function New-LMReportGroup {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMReportGroup.ps1
+++ b/Public/New-LMReportGroup.ps1
@@ -49,8 +49,8 @@ Function New-LMReportGroup {
 
             Try {
                 $Data = @{
-                    description                         = $Description
-                    name                                = $Name
+                    description = $Description
+                    name        = $Name
                 }
 
             

--- a/Public/New-LMRole.ps1
+++ b/Public/New-LMRole.ps1
@@ -90,8 +90,8 @@ Function New-LMRole {
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'Custom')]
-        [Parameter(Mandatory,ParameterSetName = 'Default')]
+        [Parameter(Mandatory, ParameterSetName = 'Custom')]
+        [Parameter(Mandatory, ParameterSetName = 'Default')]
         [String]$Name,
 
         [Parameter(ParameterSetName = 'Default')]
@@ -119,39 +119,39 @@ Function New-LMRole {
         [String]$RoleGroupId = 1,
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$DashboardsPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$ResourcePermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$LogsPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$WebsitesPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$SavedMapsPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$ReportsPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view","manage","commit","publish","none")]
+        [ValidateSet("view", "manage", "commit", "publish", "none")]
         [String]$LMXToolBoxPermission = "none",
         
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view","install","none")]
+        [ValidateSet("view", "install", "none")]
         [String]$LMXPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
-        [ValidateSet("view", "manage","none","manage-collectors","view-collectors")]
+        [ValidateSet("view", "manage", "none", "manage-collectors", "view-collectors")]
         [String]$SettingsPermission = "none",
 
         [Parameter(ParameterSetName = 'Default')]
@@ -178,7 +178,7 @@ Function New-LMRole {
         [Parameter(ParameterSetName = 'Default')]
         [Switch]$EnableRemoteSessionForResources,
 
-        [Parameter(Mandatory,ParameterSetName = 'Custom')]
+        [Parameter(Mandatory, ParameterSetName = 'Custom')]
         [PSCustomObject]$CustomPrivilegesObject
 
     )
@@ -190,202 +190,202 @@ Function New-LMRole {
         $ResourcePath = "/setting/roles"
         $Privileges = @()
 
-        If(!$CustomPrivilegesObject){
+        If (!$CustomPrivilegesObject) {
 
-            If($ViewTraces){
+            If ($ViewTraces) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "tracesManageTab"
-                    operation = "read"
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "tracesManageTab"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
 
-            If($EnableRemoteSessionForResources){
+            If ($EnableRemoteSessionForResources) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "remoteSession"
-                    operation = "write"
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "remoteSession"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($AllowedToViewMapsTab){
+            If ($AllowedToViewMapsTab) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "resourceMapTab"
-                    operation = "read"
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "resourceMapTab"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
 
-            If($AllowWidgetSharing){
+            If ($AllowWidgetSharing) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "sharingwidget"
-                    objectName = "sharingwidget"
-                    objectType = "dashboard_group"
-                    operation = "write"
+                    objectId     = "sharingwidget"
+                    objectName   = "sharingwidget"
+                    objectType   = "dashboard_group"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($CreatePrivateDashboards){
+            If ($CreatePrivateDashboards) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "private"
-                    objectName = "private"
-                    objectType = "dashboard_group"
-                    operation = "write"
+                    objectId     = "private"
+                    objectName   = "private"
+                    objectType   = "dashboard_group"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($LMXToolBoxPermission){
+            If ($LMXToolBoxPermission) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "allinstalledmodules"
+                    objectId   = "allinstalledmodules"
                     objectName = "All installed modules"
                     objectType = "module"
-                    operation = $LMXToolBoxPermission
+                    operation  = $LMXToolBoxPermission
                 }
             }
 
-            If($LMXPermission){
+            If ($LMXPermission) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "All exchange modules"
+                    objectId   = "All exchange modules"
                     objectName = "private"
                     objectType = "module"
-                    operation = $LMXPermission
+                    operation  = $LMXPermission
                 }
             }
 
-            If($ViewSupport){
+            If ($ViewSupport) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "chat"
-                    objectName = "help"
-                    objectType = "help"
-                    operation = "write"
+                    objectId     = "chat"
+                    objectName   = "help"
+                    objectType   = "help"
+                    operation    = "write"
                     subOperation = ""
                 }
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "help"
-                    objectType = "help"
-                    operation = "read"
+                    objectId     = "*"
+                    objectName   = "help"
+                    objectType   = "help"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
-            Else{
+            Else {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "chat"
-                    objectName = "help"
-                    objectType = "help"
-                    operation = "read"
+                    objectId     = "chat"
+                    objectName   = "help"
+                    objectType   = "help"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
 
             $Privileges += [PSCustomObject]@{
-                objectId = ""
-                objectName = "configNeedDeviceManagePermission"
-                objectType = "configNeedDeviceManagePermission"
-                operation = If($ConfigTabRequiresManagePermission){"write"}Else{"read"}
+                objectId     = ""
+                objectName   = "configNeedDeviceManagePermission"
+                objectType   = "configNeedDeviceManagePermission"
+                operation    = If ($ConfigTabRequiresManagePermission) { "write" }Else { "read" }
                 subOperation = ""
             }
 
             $Privileges += [PSCustomObject]@{
-                objectId = ""
-                objectName = "deviceDashboard"
-                objectType = "deviceDashboard"
-                operation = If($AllowedToManageResourceDashboards){"write"}Else{"read"}
+                objectId     = ""
+                objectName   = "deviceDashboard"
+                objectType   = "deviceDashboard"
+                operation    = If ($AllowedToManageResourceDashboards) { "write" }Else { "read" }
                 subOperation = ""
             }
 
-            If($DashboardsPermission -ne "none"){
+            If ($DashboardsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "dashboard_group"
-                    operation = If($DashboardsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "dashboard_group"
+                    operation    = If ($DashboardsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($ResourcePermission -ne "none"){
+            If ($ResourcePermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "host_group"
-                    operation = If($ResourcePermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "host_group"
+                    operation    = If ($ResourcePermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($LogsPermission -ne "none"){
+            If ($LogsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "logs"
-                    operation = If($LogsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "logs"
+                    operation    = If ($LogsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($WebsitesPermission -ne "none"){
+            If ($WebsitesPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "website_group"
-                    operation = If($WebsitesPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "website_group"
+                    operation    = If ($WebsitesPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($SavedMapsPermission -ne "none"){
+            If ($SavedMapsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "map"
-                    operation = If($SavedMapsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "map"
+                    operation    = If ($SavedMapsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($ReportsPermission -ne "none"){
+            If ($ReportsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "report_group"
-                    operation = If($ReportsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "report_group"
+                    operation    = If ($ReportsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($SettingsPermission -ne "none"){
-                If($SettingsPermission -ne "manage-collectors" -and $SettingsPermission -ne "view-collectors"){
+            If ($SettingsPermission -ne "none") {
+                If ($SettingsPermission -ne "manage-collectors" -and $SettingsPermission -ne "view-collectors") {
                     $Privileges += [PSCustomObject]@{
-                        objectId = "*"
-                        objectName = "*"
-                        objectType = "setting"
-                        operation = If($SettingsPermission -eq "manage"){"write"}Else{"read"}
+                        objectId     = "*"
+                        objectName   = "*"
+                        objectType   = "setting"
+                        operation    = If ($SettingsPermission -eq "manage") { "write" }Else { "read" }
                         subOperation = ""
                     }
 
                     $Privileges += [PSCustomObject]@{
-                        objectId = "useraccess.*"
-                        objectName = "useraccess.*"
-                        objectType = "setting"
-                        operation = If($ResourcePermission -eq "manage"){"write"}Else{"read"}
+                        objectId     = "useraccess.*"
+                        objectName   = "useraccess.*"
+                        objectType   = "setting"
+                        operation    = If ($ResourcePermission -eq "manage") { "write" }Else { "read" }
                         subOperation = ""
                     }
                 }
-                Else{
+                Else {
                     $Privileges += [PSCustomObject]@{
-                        objectId = "collectorgroup.*"
+                        objectId   = "collectorgroup.*"
                         objectName = "Collectors"
                         objectType = "setting"
-                        operation = If($SettingsPermission -eq "manage-collectors"){"write"}Else{"read"}
+                        operation  = If ($SettingsPermission -eq "manage-collectors") { "write" }Else { "read" }
                     }
                 }
             }
@@ -398,10 +398,10 @@ Function New-LMRole {
                 customHelpURL   = $CustomHelpURL
                 description     = $Description
                 name            = $Name
-                requireEULA      = $RequireEULA.IsPresent 
+                requireEULA     = $RequireEULA.IsPresent 
                 roleGroupId     = $RoleGroupId
                 twoFARequired   = $TwoFARequired
-                privileges      = If($CustomPrivilegesObject){$CustomPrivilegesObject}Else{$Privileges}
+                privileges      = If ($CustomPrivilegesObject) { $CustomPrivilegesObject }Else { $Privileges }
             }
 
             #Remove empty keys so we dont overwrite them
@@ -414,7 +414,7 @@ Function New-LMRole {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Role" )

--- a/Public/New-LMRole.ps1
+++ b/Public/New-LMRole.ps1
@@ -405,7 +405,7 @@ Function New-LMRole {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMUser.ps1
+++ b/Public/New-LMUser.ps1
@@ -159,7 +159,7 @@ Function New-LMUser {
                 }
                 break
             }
-            ElseIf ($ViewPermission.ContainsKey($View)) {
+            Elseif ($ViewPermission.ContainsKey($View)) {
                 $ViewPermission[$View] = $true
             }
         }
@@ -197,7 +197,7 @@ Function New-LMUser {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/New-LMUser.ps1
+++ b/Public/New-LMUser.ps1
@@ -166,7 +166,7 @@ Function New-LMUser {
 
         #Auto generate password if not provided
         $AutoGeneratePassword = $False
-        If(!$Password){
+        If (!$Password) {
             $Password = New-LMRandomCred
             $AutoGeneratePassword = $True
         }
@@ -206,16 +206,16 @@ Function New-LMUser {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
-            If($AutoGeneratePassword){
-                If(!$global:LMUserData){
+            If ($AutoGeneratePassword) {
+                If (!$global:LMUserData) {
                     $UserData = New-Object System.Collections.ArrayList
-                    $UserData.Add([PSCustomObject]@{"Username"=$Username;"Temp_Password"=$Password}) | Out-Null
+                    $UserData.Add([PSCustomObject]@{"Username" = $Username; "Temp_Password" = $Password }) | Out-Null
                     New-Variable -Name LMUserData -Scope global -Value $UserData
                 }
-                Else{
-                    $global:LMUserData.Add([PSCustomObject]@{"Username"=$Username;"Temp_Password"=$Password}) | Out-Null
+                Else {
+                    $global:LMUserData.Add([PSCustomObject]@{"Username" = $Username; "Temp_Password" = $Password }) | Out-Null
                 }
                 
                 Write-LMHost "[INFO]: Auto generated password assigned to $Username`: $Password" -ForegroundColor Yellow

--- a/Public/New-LMWebsite.ps1
+++ b/Public/New-LMWebsite.ps1
@@ -290,7 +290,7 @@ Function New-LMWebsite {
                 $Data.testLocation = $TestLocations
             }
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "testLocation" -and $_ -ne "steps" -and $_ -ne "checkpoints") { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "testLocation" -and $_ -ne "steps" -and $_ -ne "checkpoints") { $Data.Remove($_) } }
             $Data = ($Data | ConvertTo-Json -Depth 5)
             
             $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMWebsite.ps1
+++ b/Public/New-LMWebsite.ps1
@@ -107,10 +107,10 @@ Function New-LMWebsite {
 
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory,ParameterSetName="Website")]
+        [Parameter(Mandatory, ParameterSetName = "Website")]
         [Switch]$WebCheck,
 
-        [Parameter(Mandatory,ParameterSetName="Ping")]
+        [Parameter(Mandatory, ParameterSetName = "Ping")]
         [Switch]$PingCheck,
 
         [Parameter(Mandatory)]
@@ -128,41 +128,41 @@ Function New-LMWebsite {
 
         [Nullable[boolean]]$UseDefaultLocationSetting = $true,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[boolean]]$TriggerSSLStatusAlert,
         
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[boolean]]$TriggerSSLExpirationAlert,
 
         [String]$GroupId,
 
-        [Parameter(Mandatory,ParameterSetName="Ping")]
+        [Parameter(Mandatory, ParameterSetName = "Ping")]
         [String]$PingAddress,
 
-        [Parameter(Mandatory,ParameterSetName="Website")]
+        [Parameter(Mandatory, ParameterSetName = "Website")]
         [String]$WebsiteDomain,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [ValidateSet("http", "https")]
         [String]$HttpType = "https",
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [String[]]$SSLAlertThresholds,
 
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [ValidateSet(5, 10, 15, 20, 30, 60)]
         [Nullable[Int]]$PingCount,
 
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [Nullable[Int]]$PingTimeout,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[Int]]$PageLoadAlertTimeInMS,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[boolean]]$IgnoreSSL,
 
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [ValidateSet(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)]
         [Nullable[Int]]$PingPercentNotReceived,
 
@@ -183,29 +183,29 @@ Function New-LMWebsite {
         [ValidateSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
         [Nullable[Int]]$PollingInterval,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Object[]]$WebsiteSteps,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Object[]]$CheckPoints
     )
     #Check if we are logged in and have valid api creds
     If ($Script:LMAuth.Valid) {
 
-        If($Webcheck){
+        If ($Webcheck) {
             $Type = "webcheck"
         }
-        Else{
+        Else {
             $Type = "pingcheck"
         }
 
         
         $Steps = @()
         If ($Type -eq "webcheck") {
-            If($WebsiteSteps){
+            If ($WebsiteSteps) {
                 $Steps = $WebsiteSteps
             }
-            Else{
+            Else {
                 $Steps += [PSCustomObject]@{
                     useDefaultRoot    = $true
                     url               = ""
@@ -279,18 +279,18 @@ Function New-LMWebsite {
                 steps                       = $Steps
             }
             
-            If($CheckPoints){
+            If ($CheckPoints) {
                 $TestLocations = [PSCustomObject]@{
-                    all = $true
-                    smgIds = @()
-                    collectorIds = @($CheckPoints.smgId.GetEnumerator() | Foreach-Object {If($_ -ne 0){[Int]$_}})
+                    all          = $true
+                    smgIds       = @()
+                    collectorIds = @($CheckPoints.smgId.GetEnumerator() | ForEach-Object { If ($_ -ne 0) { [Int]$_ } })
                 }
 
-                $Data.checkpoints  = $CheckPoints
+                $Data.checkpoints = $CheckPoints
                 $Data.testLocation = $TestLocations
             }
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "testLocation" -and $_ -ne "steps" -and  $_ -ne "checkpoints") { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "testLocation" -and $_ -ne "steps" -and $_ -ne "checkpoints") { $Data.Remove($_) } }
             $Data = ($Data | ConvertTo-Json -Depth 5)
             
             $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/New-LMWebsiteGroup.ps1
+++ b/Public/New-LMWebsiteGroup.ps1
@@ -102,7 +102,7 @@ Function New-LMWebsiteGroup {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.WebsiteGroup" )

--- a/Public/Remove-LMAPIToken.ps1
+++ b/Public/Remove-LMAPIToken.ps1
@@ -42,7 +42,7 @@ This function requires a valid API authentication. Make sure to log in using Con
 #>
 Function Remove-LMAPIToken {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id')]
         [Int]$UserId,
@@ -58,8 +58,8 @@ Function Remove-LMAPIToken {
         [Int]$APITokenId
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -72,7 +72,7 @@ Function Remove-LMAPIToken {
                 $UserId = $LookupResult
             }
 
-            If($AccessId){
+            If ($AccessId) {
                 $LookupResult = (Get-LMAPIToken -AccessId $AccessId)
                 If (Test-LookupResult -Result $LookupResult -LookupString $AccessId) {
                     return
@@ -84,10 +84,10 @@ Function Remove-LMAPIToken {
             #Build header and uri
             $ResourcePath = "/setting/admins/$UserId/apitokens/$APITokenId"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $APITokenId | AccessId: $($PSItem.accessId)| AdminName:$($PSItem.adminName)"
             }
-            Else{
+            Else {
                 $Message = "Id: $APITokenId"
             }
 
@@ -98,11 +98,11 @@ Function Remove-LMAPIToken {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $APITokenId
+                        Id      = $APITokenId
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -120,5 +120,5 @@ Function Remove-LMAPIToken {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     } 
-    End{}
+    End {}
 }

--- a/Public/Remove-LMAPIToken.ps1
+++ b/Public/Remove-LMAPIToken.ps1
@@ -92,7 +92,7 @@ Function Remove-LMAPIToken {
             }
 
             Try {
-                if ($PSCmdlet.ShouldProcess($Message, "Remove API Token")) {                    
+                If ($PSCmdlet.ShouldProcess($Message, "Remove API Token")) {                    
                     $Headers = New-LMHeader -Auth $Script:LMAuth -Method "DELETE" -ResourcePath $ResourcePath
                     $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
     

--- a/Public/Remove-LMAccessGroup.ps1
+++ b/Public/Remove-LMAccessGroup.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+Removes a LogicMonitor access group.
+
+.DESCRIPTION
+The Remove-LMAccessGroup function removes a LogicMonitor access group based on the specified ID or name.
+
+.PARAMETER Id
+The ID of the access group to remove. This parameter is mandatory when using the 'Id' parameter set.
+
+.PARAMETER Name
+The name of the access group to remove. This parameter is mandatory when using the 'Name' parameter set.
+
+.EXAMPLE
+Remove-LMAccessGroup -Id 123
+Removes the access group with the ID 123.
+
+.EXAMPLE
+Remove-LMAccessGroup -Name "MyAccessGroup"
+Removes the access group with the name "MyAccessGroup".
+
+.INPUTS
+None.
+
+.OUTPUTS
+System.Management.Automation.PSCustomObject
+
+.NOTES
+This function requires a valid LogicMonitor API authentication. Make sure to log in using Connect-LMAccount before running this command.
+#>
+Function Remove-LMAccessGroup {
+
+    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
+        [Int]$Id,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String]$Name
+    )
+    Begin {}
+    Process {
+        #Check if we are logged in and have valid api creds
+        If ($Script:LMAuth.Valid) {
+
+            #Lookup Id if supplying username
+            If ($Name) {
+                $LookupResult = (Get-LMAccessGroup -Name $Name).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $Id = $LookupResult
+            }
+
+            If($PSItem){
+                $Message = "Id: $Id | Name: $($PSItem.name)"
+            }
+            ElseIf($Name){
+                $Message = "Id: $Id | Name: $Name"
+            }
+            Else{
+                $Message = "Id: $Id"
+            }
+            
+            #Build header and uri
+            $ResourcePath = "/setting/accessgroup/$Id"
+
+            Try {
+                If ($PSCmdlet.ShouldProcess($Message, "Remove AccessGroup")) {                    
+                    $Headers = New-LMHeader -Auth $Script:LMAuth -Method "DELETE" -ResourcePath $ResourcePath
+                    $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+    
+                    Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+                #Issue request
+                    $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
+                    
+                    $Result = [PSCustomObject]@{
+                        Id = $Id
+                        Message = "Successfully removed ($Message)"
+                    }
+                    
+                    Return $Result
+                }
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {}
+}

--- a/Public/Remove-LMAppliesToFunction.ps1
+++ b/Public/Remove-LMAppliesToFunction.ps1
@@ -59,7 +59,7 @@ Function Remove-LMAppliesToFunction {
             If ($PSItem) {
                 $Message = "Id: $Id | Name:$($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMAppliesToFunction.ps1
+++ b/Public/Remove-LMAppliesToFunction.ps1
@@ -30,12 +30,12 @@ System.Management.Automation.PSCustomObject. The function returns an object with
 #>
 Function Remove-LMAppliesToFunction {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Name')]
         [String]$Name,
 
-        [Parameter(Mandatory, ParameterSetName = 'Id',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id
 
     )
@@ -56,13 +56,13 @@ Function Remove-LMAppliesToFunction {
             #Build header and uri
             $ResourcePath = "/setting/functions/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name:$($PSItem.name)"
             }
             ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -73,11 +73,11 @@ Function Remove-LMAppliesToFunction {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMCachedAccount.ps1
+++ b/Public/Remove-LMCachedAccount.ps1
@@ -24,7 +24,7 @@ Removes all cached accounts from the Logic.Monitor vault.
 #>
 
 Function Remove-LMCachedAccount {
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Single', ValueFromPipelineByPropertyName)]
         [Alias("Portal")]
@@ -33,34 +33,34 @@ Function Remove-LMCachedAccount {
         [Parameter(ParameterSetName = 'All')]
         [Switch]$RemoveAllEntries
     )
-    Begin{}
-    Process{
-        If($RemoveAllEntries){
+    Begin {}
+    Process {
+        If ($RemoveAllEntries) {
             $CachedAccounts = Get-SecretInfo -Vault Logic.Monitor
             if ($PSCmdlet.ShouldProcess("$(($CachedAccounts | Measure-Object).Count) cached account(s)", "Remove All Cached Accounts")) {                
-                Foreach ($Account in $CachedAccounts.Name){
-                    Try{
+                Foreach ($Account in $CachedAccounts.Name) {
+                    Try {
                         Remove-Secret -Name $Account -Vault Logic.Monitor -Confirm:$false -ErrorAction Stop
                         Write-Host "[INFO]: Removed cached account secret for: $Account"
                     }
-                    Catch{
+                    Catch {
                         Write-Error $_.Exception.Message
                     }
                 }
                 Write-Host "[INFO]: Processed all entries from credential cache"
             }
         }
-        Else{
+        Else {
             If ($PSCmdlet.ShouldProcess($CachedAccountName, "Remove Cached Account")) {                
-                Try{
+                Try {
                     Remove-Secret -Name $CachedAccountName -Vault Logic.Monitor -Confirm:$false -ErrorAction Stop
                     Write-Host "[INFO]: Removed cached account secret for: $CachedAccountName"
                 }
-                Catch{
+                Catch {
                     Write-Error $_.Exception.Message
                 }
             }
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMCachedAccount.ps1
+++ b/Public/Remove-LMCachedAccount.ps1
@@ -37,7 +37,7 @@ Function Remove-LMCachedAccount {
     Process {
         If ($RemoveAllEntries) {
             $CachedAccounts = Get-SecretInfo -Vault Logic.Monitor
-            if ($PSCmdlet.ShouldProcess("$(($CachedAccounts | Measure-Object).Count) cached account(s)", "Remove All Cached Accounts")) {                
+            If ($PSCmdlet.ShouldProcess("$(($CachedAccounts | Measure-Object).Count) cached account(s)", "Remove All Cached Accounts")) {                
                 Foreach ($Account in $CachedAccounts.Name) {
                     Try {
                         Remove-Secret -Name $Account -Vault Logic.Monitor -Confirm:$false -ErrorAction Stop

--- a/Public/Remove-LMCollectorGroup.ps1
+++ b/Public/Remove-LMCollectorGroup.ps1
@@ -30,7 +30,7 @@ This function requires valid API credentials to be logged in. Use Connect-LMAcco
 #>
 Function Remove-LMCollectorGroup {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -53,13 +53,13 @@ Function Remove-LMCollectorGroup {
                 $Id = $LookupResult
             }
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $($PSItem.id) | Name: $($PSItem.name)"
             }
             ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
             
@@ -73,11 +73,11 @@ Function Remove-LMCollectorGroup {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
  
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMCollectorGroup.ps1
+++ b/Public/Remove-LMCollectorGroup.ps1
@@ -56,7 +56,7 @@ Function Remove-LMCollectorGroup {
             If ($PSItem) {
                 $Message = "Id: $($PSItem.id) | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMConfigsource.ps1
+++ b/Public/Remove-LMConfigsource.ps1
@@ -33,7 +33,7 @@ Please ensure you are logged in before running any commands. Use Connect-LMAccou
 #>
 Function Remove-LMConfigsource {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -43,8 +43,8 @@ Function Remove-LMConfigsource {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -61,13 +61,13 @@ Function Remove-LMConfigsource {
             #Build header and uri
             $ResourcePath = "/setting/configsources/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -78,11 +78,11 @@ Function Remove-LMConfigsource {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
 
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -100,5 +100,5 @@ Function Remove-LMConfigsource {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMConfigsource.ps1
+++ b/Public/Remove-LMConfigsource.ps1
@@ -64,7 +64,7 @@ Function Remove-LMConfigsource {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMDashboard.ps1
+++ b/Public/Remove-LMDashboard.ps1
@@ -32,7 +32,7 @@ System.Management.Automation.PSCustomObject. The function returns an object with
 #>
 Function Remove-LMDashboard {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -41,8 +41,8 @@ Function Remove-LMDashboard {
         [String]$Name
 
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -58,13 +58,13 @@ Function Remove-LMDashboard {
             #Build header and uri
             $ResourcePath = "/dashboard/dashboards/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -75,11 +75,11 @@ Function Remove-LMDashboard {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -97,5 +97,5 @@ Function Remove-LMDashboard {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMDashboard.ps1
+++ b/Public/Remove-LMDashboard.ps1
@@ -61,7 +61,7 @@ Function Remove-LMDashboard {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMDashboardGroup.ps1
+++ b/Public/Remove-LMDashboardGroup.ps1
@@ -53,7 +53,7 @@ Function Remove-LMDashboardGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMDashboardGroup.ps1
+++ b/Public/Remove-LMDashboardGroup.ps1
@@ -24,7 +24,7 @@ None.
 #>
 Function Remove-LMDashboardGroup {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -33,8 +33,8 @@ Function Remove-LMDashboardGroup {
         [String]$Name
 
     )
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -50,13 +50,13 @@ Function Remove-LMDashboardGroup {
             #Build header and uri
             $ResourcePath = "/dashboard/groups/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -67,11 +67,11 @@ Function Remove-LMDashboardGroup {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -89,5 +89,5 @@ Function Remove-LMDashboardGroup {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMDashboardWidget.ps1
+++ b/Public/Remove-LMDashboardWidget.ps1
@@ -33,7 +33,7 @@ This function requires a valid API authentication to Logic Monitor. Make sure to
 #>
 Function Remove-LMDashboardWidget {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -43,8 +43,8 @@ Function Remove-LMDashboardWidget {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -60,13 +60,13 @@ Function Remove-LMDashboardWidget {
             #Build header and uri
             $ResourcePath = "/dashboard/widgets/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -77,11 +77,11 @@ Function Remove-LMDashboardWidget {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -99,5 +99,5 @@ Function Remove-LMDashboardWidget {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMDashboardWidget.ps1
+++ b/Public/Remove-LMDashboardWidget.ps1
@@ -63,7 +63,7 @@ Function Remove-LMDashboardWidget {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMDatasource.ps1
+++ b/Public/Remove-LMDatasource.ps1
@@ -34,7 +34,7 @@ System.Management.Automation.PSCustomObject
 #>
 Function Remove-LMDatasource {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -47,8 +47,8 @@ Function Remove-LMDatasource {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -73,10 +73,10 @@ Function Remove-LMDatasource {
             #Build header and uri
             $ResourcePath = "/setting/datasources/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -87,11 +87,11 @@ Function Remove-LMDatasource {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -109,5 +109,5 @@ Function Remove-LMDatasource {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMDevice.ps1
+++ b/Public/Remove-LMDevice.ps1
@@ -65,7 +65,7 @@ Function Remove-LMDevice {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMDevice.ps1
+++ b/Public/Remove-LMDevice.ps1
@@ -37,7 +37,7 @@ Permanently deletes the LogicMonitor device with the name "MyDevice".
 #>
 Function Remove-LMDevice {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -62,13 +62,13 @@ Function Remove-LMDevice {
                 $Id = $LookupResult
             }
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
             
@@ -84,11 +84,11 @@ Function Remove-LMDevice {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMDeviceDatasourceInstance.ps1
+++ b/Public/Remove-LMDeviceDatasourceInstance.ps1
@@ -96,7 +96,7 @@ Function Remove-LMDeviceDatasourceInstance {
             If ($PSItem) {
                 $Message = "DeviceDisplayName: $($PSItem.deviceDisplayName) | DatasourceName: $($PSItem.name) | WildValue: $($PSItem.wildValue)"
             }
-            ElseIf ($DatasourceName -and $DeviceName) {
+            Elseif ($DatasourceName -and $DeviceName) {
                 $Message = "DeviceName: $DeviceName | DatasourceName: $DatasourceName | WildValue: $WildValue"
             }
             Else {

--- a/Public/Remove-LMDeviceDatasourceInstance.ps1
+++ b/Public/Remove-LMDeviceDatasourceInstance.ps1
@@ -37,7 +37,7 @@ A custom object with the following properties:
 - Message: A message indicating the success of the removal.
 #>
 Function Remove-LMDeviceDatasourceInstance {
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
@@ -60,8 +60,8 @@ Function Remove-LMDeviceDatasourceInstance {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -93,13 +93,13 @@ Function Remove-LMDeviceDatasourceInstance {
             #Build header and uri
             $ResourcePath = "/device/devices/$DeviceId/devicedatasources/$HdsId/instances/$InstanceId"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "DeviceDisplayName: $($PSItem.deviceDisplayName) | DatasourceName: $($PSItem.name) | WildValue: $($PSItem.wildValue)"
             }
-            ElseIf($DatasourceName -and $DeviceName){
+            ElseIf ($DatasourceName -and $DeviceName) {
                 $Message = "DeviceName: $DeviceName | DatasourceName: $DatasourceName | WildValue: $WildValue"
             }
-            Else{
+            Else {
                 $Message = "DeviceId: $DeviceId | DatasourceId: $DatasourceId | WildValue: $WildValue"
             }
 
@@ -110,12 +110,12 @@ Function Remove-LMDeviceDatasourceInstance {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
                         InstanceId = $InstanceId
-                        Message = "Successfully removed ($Message)"
+                        Message    = "Successfully removed ($Message)"
                     }
                     
                     Return $Result
@@ -132,5 +132,5 @@ Function Remove-LMDeviceDatasourceInstance {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMDeviceDatasourceInstanceGroup.ps1
+++ b/Public/Remove-LMDeviceDatasourceInstanceGroup.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+Removes a LogicMonitor device datasource instance group.
+
+.DESCRIPTION
+The Remove-LMDeviceDatasourceInstanceGroup function removes a LogicMonitor device datasource instance group based on the provided parameters. It requires valid API credentials and a logged-in session.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource associated with the instance group. This parameter is mandatory when using the 'Id-dsName' or 'Name-dsName' parameter sets.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource associated with the instance group. This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter sets.
+
+.PARAMETER Id
+Specifies the ID of the device associated with the instance group. This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter sets. This parameter can also be specified using the 'DeviceId' alias.
+
+.PARAMETER Name
+Specifies the name of the device associated with the instance group. This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter sets. This parameter can also be specified using the 'DeviceName' alias.
+
+.PARAMETER InstanceGroupName
+Specifies the name of the instance group to be removed. This parameter is mandatory.
+
+.EXAMPLE
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceName "CPU" -Name "Server01" -InstanceGroupName "Group1"
+Removes the instance group named "Group1" associated with the "CPU" datasource on the device named "Server01".
+
+.EXAMPLE
+Remove-LMDeviceDatasourceInstanceGroup -DatasourceId 123 -Id 456 -InstanceGroupName "Group2"
+Removes the instance group named "Group2" associated with the datasource ID 123 on the device ID 456.
+
+.INPUTS
+None. You cannot pipe objects to this function.
+#>
+
+Function Remove-LMDeviceDatasourceInstanceGroup {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [String]$DatasourceName,
+    
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Int]$DatasourceId,
+    
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Alias('DeviceId')]
+        [Int]$Id,
+    
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Alias('DeviceName')]
+        [String]$Name,
+
+        [Parameter(Mandatory)]
+        [String]$InstanceGroupName
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+
+        #Lookup Device Id
+        If ($Name) {
+            $LookupResult = (Get-LMDevice -Name $Name).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                return
+            }
+            $Id = $LookupResult
+        }
+
+        #Lookup DatasourceId
+        If ($DatasourceName -or $DatasourceId) {
+            $LookupResult = (Get-LMDeviceDataSourceList -Id $Id | Where-Object { $_.dataSourceName -eq $DatasourceName -or $_.dataSourceId -eq $DatasourceId }).Id
+            If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceName) {
+                return
+            }
+            $HdsId = $LookupResult
+        }
+
+        #Lookup InstanceGroupId
+        $LookupResult = (Get-LMDeviceDatasourceInstanceGroup -Id $Id -HdsId $HdsId -Filter "name -eq '$InstanceGroupName'").Id
+        If (Test-LookupResult -Result $LookupResult -LookupString $InstanceGroupName) {
+            return
+        }
+        $InstanceGroupId = $LookupResult
+        
+        #Build header and uri
+        $ResourcePath = "/device/devices/$Id/devicedatasources/$HdsId/groups/$InstanceGroupId"
+
+        If ($PSItem) {
+            $Message = "DeviceDisplayName: $($PSItem.deviceDisplayName) | DatasourceName: $($PSItem.name) | InstanceGroupName: $($PSItem.InstanceGroupName)"
+        }
+        Elseif ($DatasourceName -and $DeviceName) {
+            $Message = "DeviceName: $DeviceName | DatasourceName: $DatasourceName | InstanceGroupName: $InstanceGroupName"
+        }
+        Else {
+            $Message = "DeviceId: $DeviceId | DatasourceId: $DatasourceId | InstanceGroupName: $InstanceGroupName"
+        }
+
+        Try {
+            If ($PSCmdlet.ShouldProcess($Message, "Remove Device Datasource Instance Group")) {                    
+                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "DELETE" -ResourcePath $ResourcePath
+                $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+                #Issue request
+                $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
+                
+                $Result = [PSCustomObject]@{
+                    InstanceId = $InstanceId
+                    Message    = "Successfully removed ($Message)"
+                }
+                
+                Return $Result
+            }
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Remove-LMDeviceGroup.ps1
+++ b/Public/Remove-LMDeviceGroup.ps1
@@ -61,13 +61,13 @@ Function Remove-LMDeviceGroup {
 
             $QueryParams = "?deleteChildren=$DeleteHostsandChildren&deleteHard=$HardDelete"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -78,11 +78,11 @@ Function Remove-LMDeviceGroup {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMDeviceGroup.ps1
+++ b/Public/Remove-LMDeviceGroup.ps1
@@ -64,7 +64,7 @@ Function Remove-LMDeviceGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMDeviceProperty.ps1
+++ b/Public/Remove-LMDeviceProperty.ps1
@@ -36,7 +36,7 @@ System.Management.Automation.PSCustomObject. The output object contains the foll
 #>
 Function Remove-LMDeviceProperty {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id')]
         [Int]$Id,
@@ -65,10 +65,10 @@ Function Remove-LMDeviceProperty {
             #Build header and uri
             $ResourcePath = "/device/devices/$Id/properties/$PropertyName"
 
-            If($Name){
+            If ($Name) {
                 $Message = "Id: $Id | Name: $Name | Property: $PropertyName"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id | Property: $PropertyName"
             }
 
@@ -79,11 +79,11 @@ Function Remove-LMDeviceProperty {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -101,5 +101,5 @@ Function Remove-LMDeviceProperty {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMNetscan.ps1
+++ b/Public/Remove-LMNetscan.ps1
@@ -59,7 +59,7 @@ Function Remove-LMNetscan {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMNetscan.ps1
+++ b/Public/Remove-LMNetscan.ps1
@@ -29,7 +29,7 @@ System.Management.Automation.PSCustomObject. The function returns an object with
 #>
 Function Remove-LMNetscan {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -39,8 +39,8 @@ Function Remove-LMNetscan {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -56,13 +56,13 @@ Function Remove-LMNetscan {
             #Build header and uri
             $ResourcePath = "/setting/netscans/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -74,11 +74,11 @@ Function Remove-LMNetscan {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -96,5 +96,5 @@ Function Remove-LMNetscan {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMNetscanGroup.ps1
+++ b/Public/Remove-LMNetscanGroup.ps1
@@ -33,7 +33,7 @@ This function requires valid API credentials to be logged in. Use the Connect-LM
 #>
 Function Remove-LMNetscanGroup {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -56,13 +56,13 @@ Function Remove-LMNetscanGroup {
                 $Id = $LookupResult
             }
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
             
@@ -76,11 +76,11 @@ Function Remove-LMNetscanGroup {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMNetscanGroup.ps1
+++ b/Public/Remove-LMNetscanGroup.ps1
@@ -59,7 +59,7 @@ Function Remove-LMNetscanGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMOpsNote.ps1
+++ b/Public/Remove-LMOpsNote.ps1
@@ -21,7 +21,7 @@ Returns an object with the ID and a success message if the OpsNote is successful
 #>
 Function Remove-LMOpsNote {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [String]$Id
@@ -45,11 +45,11 @@ Function Remove-LMOpsNote {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMPropertysource.ps1
+++ b/Public/Remove-LMPropertysource.ps1
@@ -29,7 +29,7 @@ System.Management.Automation.PSCustomObject. The function returns an object with
 #>
 Function Remove-LMPropertysource {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -39,8 +39,8 @@ Function Remove-LMPropertysource {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -57,13 +57,13 @@ Function Remove-LMPropertysource {
             #Build header and uri
             $ResourcePath = "/setting/propertyrules/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -74,11 +74,11 @@ Function Remove-LMPropertysource {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -96,5 +96,5 @@ Function Remove-LMPropertysource {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMPropertysource.ps1
+++ b/Public/Remove-LMPropertysource.ps1
@@ -60,7 +60,7 @@ Function Remove-LMPropertysource {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMReport.ps1
+++ b/Public/Remove-LMReport.ps1
@@ -30,7 +30,7 @@ This function requires a valid API authentication and authorization. Use Connect
 #>
 Function Remove-LMReport {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -53,13 +53,13 @@ Function Remove-LMReport {
                 $Id = $LookupResult
             }
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
             
@@ -73,11 +73,11 @@ Function Remove-LMReport {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMReport.ps1
+++ b/Public/Remove-LMReport.ps1
@@ -56,7 +56,7 @@ Function Remove-LMReport {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMReportGroup.ps1
+++ b/Public/Remove-LMReportGroup.ps1
@@ -53,7 +53,7 @@ Function Remove-LMReportGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMReportGroup.ps1
+++ b/Public/Remove-LMReportGroup.ps1
@@ -27,7 +27,7 @@ System.Management.Automation.PSCustomObject. Returns an object with the removed 
 #>
 Function Remove-LMReportGroup {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -50,13 +50,13 @@ Function Remove-LMReportGroup {
                 $Id = $LookupResult
             }
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
             
@@ -70,11 +70,11 @@ Function Remove-LMReportGroup {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMRole.ps1
+++ b/Public/Remove-LMRole.ps1
@@ -30,7 +30,7 @@ This function requires a valid API authentication and authorization. Use Connect
 #>
 Function Remove-LMRole {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -56,13 +56,13 @@ Function Remove-LMRole {
             #Build header and uri
             $ResourcePath = "/setting/roles/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -74,11 +74,11 @@ Function Remove-LMRole {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMRole.ps1
+++ b/Public/Remove-LMRole.ps1
@@ -59,7 +59,7 @@ Function Remove-LMRole {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMSDT.ps1
+++ b/Public/Remove-LMSDT.ps1
@@ -1,6 +1,6 @@
 Function Remove-LMSDT {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [String]$Id
@@ -24,11 +24,11 @@ Function Remove-LMSDT {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMTopologysource.ps1
+++ b/Public/Remove-LMTopologysource.ps1
@@ -1,6 +1,6 @@
 Function Remove-LMTopologysource {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -10,8 +10,8 @@ Function Remove-LMTopologysource {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -28,13 +28,13 @@ Function Remove-LMTopologysource {
             #Build header and uri
             $ResourcePath = "/setting/topologysources/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -45,11 +45,11 @@ Function Remove-LMTopologysource {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -67,5 +67,5 @@ Function Remove-LMTopologysource {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMTopologysource.ps1
+++ b/Public/Remove-LMTopologysource.ps1
@@ -31,7 +31,7 @@ Function Remove-LMTopologysource {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMUnmonitoredDevice.ps1
+++ b/Public/Remove-LMUnmonitoredDevice.ps1
@@ -1,6 +1,6 @@
 Function Remove-LMUnmonitoredDevice {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id')]
         [String[]]$Ids
@@ -26,7 +26,7 @@ Function Remove-LMUnmonitoredDevice {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
                     
                     Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.UnmonitoredDevice" )

--- a/Public/Remove-LMUnmonitoredDevice.ps1
+++ b/Public/Remove-LMUnmonitoredDevice.ps1
@@ -17,7 +17,7 @@ Function Remove-LMUnmonitoredDevice {
             $Message = "Id(s): $Ids"
     
             Try {
-                if ($PSCmdlet.ShouldProcess($Message, "Remove Unmonitored Devices")) {                    
+                If ($PSCmdlet.ShouldProcess($Message, "Remove Unmonitored Devices")) {                    
                     [String[]]$Data = $Ids
                     $Data = ($Data | ConvertTo-Json -AsArray)
     

--- a/Public/Remove-LMUser.ps1
+++ b/Public/Remove-LMUser.ps1
@@ -29,7 +29,7 @@ Function Remove-LMUser {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.username)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMUser.ps1
+++ b/Public/Remove-LMUser.ps1
@@ -1,6 +1,6 @@
 Function Remove-LMUser {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -26,13 +26,13 @@ Function Remove-LMUser {
             #Build header and uri
             $ResourcePath = "/setting/admins/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.username)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -44,11 +44,11 @@ Function Remove-LMUser {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Remove-LMWebsite.ps1
+++ b/Public/Remove-LMWebsite.ps1
@@ -1,6 +1,6 @@
 Function Remove-LMWebsite {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -10,8 +10,8 @@ Function Remove-LMWebsite {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -27,13 +27,13 @@ Function Remove-LMWebsite {
             #Build header and uri
             $ResourcePath = "/website/websites/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -44,11 +44,11 @@ Function Remove-LMWebsite {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     
@@ -66,5 +66,5 @@ Function Remove-LMWebsite {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Remove-LMWebsite.ps1
+++ b/Public/Remove-LMWebsite.ps1
@@ -30,7 +30,7 @@ Function Remove-LMWebsite {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMWebsiteGroup.ps1
+++ b/Public/Remove-LMWebsiteGroup.ps1
@@ -35,7 +35,7 @@ Function Remove-LMWebsiteGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {

--- a/Public/Remove-LMWebsiteGroup.ps1
+++ b/Public/Remove-LMWebsiteGroup.ps1
@@ -1,6 +1,6 @@
 Function Remove-LMWebsiteGroup {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='High')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$Id,
@@ -32,13 +32,13 @@ Function Remove-LMWebsiteGroup {
             $ResourcePath = "/website/groups/$Id"
             $QueryParams = "?deleteChildren=$deleteChildren"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -49,11 +49,11 @@ Function Remove-LMWebsiteGroup {
     
                     Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
-                #Issue request
+                    #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
                     
                     $Result = [PSCustomObject]@{
-                        Id = $Id
+                        Id      = $Id
                         Message = "Successfully removed ($Message)"
                     }
                     

--- a/Public/Send-LMLogMessage.ps1
+++ b/Public/Send-LMLogMessage.ps1
@@ -80,7 +80,7 @@ Function Send-LMLogMessage {
                     }
     
                     #Remove empty keys so we dont overwrite them
-                    @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+                    @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
                     $Entries += $Data
                     $Entries = ConvertTo-Json -InputObject $Entries
                 }

--- a/Public/Send-LMPushMetric.ps1
+++ b/Public/Send-LMPushMetric.ps1
@@ -101,7 +101,7 @@ Function Send-LMPushMetric {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "instances") { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "instances") { $Data.Remove($_) } }
                 $Data = ($Data | ConvertTo-Json -Depth 10)
 
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data

--- a/Public/Send-LMPushMetric.ps1
+++ b/Public/Send-LMPushMetric.ps1
@@ -78,7 +78,7 @@ Function Send-LMPushMetric {
         If ($Script:LMAuth.Valid) {
 
             $QueryParams = $null
-            If($NewResourceHostName){
+            If ($NewResourceHostName) {
                 $QueryParams = "?create=true"
             }
                     
@@ -88,15 +88,15 @@ Function Send-LMPushMetric {
 
             Try {
                 $Data = @{
-                    resourceName            = $NewResourceHostName
-                    resourceDescription     = $NewResourceDescription
-                    resourceIds             = $ResourceIds
-                    resourceProperties      = $ResourceProperties
-                    dataSourceId            = $DatasourceId
-                    dataSource              = ($DatasourceName -replace '[#\\;=]', '_')
-                    dataSourceDisplayName   = ($DatasourceDisplayName -replace '[#\\;=]', '_')
-                    dataSourceGroup         = $DatasourceGroup
-                    instances               = $Instances
+                    resourceName          = $NewResourceHostName
+                    resourceDescription   = $NewResourceDescription
+                    resourceIds           = $ResourceIds
+                    resourceProperties    = $ResourceProperties
+                    dataSourceId          = $DatasourceId
+                    dataSource            = ($DatasourceName -replace '[#\\;=]', '_')
+                    dataSourceDisplayName = ($DatasourceDisplayName -replace '[#\\;=]', '_')
+                    dataSourceGroup       = $DatasourceGroup
+                    instances             = $Instances
 
                 }
 

--- a/Public/Set-LMAPIToken.ps1
+++ b/Public/Set-LMAPIToken.ps1
@@ -1,6 +1,6 @@
 Function Set-LMAPIToken {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [Int]$AdminId,
@@ -18,8 +18,8 @@ Function Set-LMAPIToken {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -35,10 +35,10 @@ Function Set-LMAPIToken {
             #Build header and uri
             $ResourcePath = "/setting/admins/$AdminId/apitokens/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | AccessId: $($PSItem.accessId)| AdminName:$($PSItem.adminName)"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
@@ -80,5 +80,5 @@ Function Set-LMAPIToken {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMAPIToken.ps1
+++ b/Public/Set-LMAPIToken.ps1
@@ -49,7 +49,7 @@ Function Set-LMAPIToken {
                 }
                 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
                 
                 If ($Status) {
                     $Data.status = $(If ($Status -eq "active") { 2 }Else { 1 })

--- a/Public/Set-LMAccessGroup.ps1
+++ b/Public/Set-LMAccessGroup.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+Sets the properties of a LogicMonitor access group.
+
+.DESCRIPTION
+The Set-LMAccessGroup function is used to set the properties of a LogicMonitor access group. It allows you to specify the access group either by its ID or by its name. You can set the new name, description, and tenant ID for the access group.
+
+.PARAMETER Id
+Specifies the ID of the access group. This parameter is used when you want to set the properties of the access group by its ID.
+
+.PARAMETER Name
+Specifies the name of the access group. This parameter is used when you want to set the properties of the access group by its name.
+
+.PARAMETER NewName
+Specifies the new name for the access group.
+
+.PARAMETER Description
+Specifies the new description for the access group.
+
+.PARAMETER Tenant
+Specifies the tenant ID for the access group.
+
+.EXAMPLE
+Set-LMAccessGroup -Id 123 -NewName "New Access Group" -Description "This is a new access group" -Tenant "abc123"
+Sets the properties of the access group with ID 123. The new name is set to "New Access Group", the description is set to "This is a new access group", and the tenant ID is set to "abc123".
+
+.EXAMPLE
+Set-LMAccessGroup -Name "Old Access Group" -NewName "New Access Group" -Description "This is a new access group" -Tenant "abc123"
+Sets the properties of the access group with name "Old Access Group". The new name is set to "New Access Group", the description is set to "This is a new access group", and the tenant ID is set to "abc123".
+
+.NOTES
+This function requires you to be logged in and have valid API credentials. Use the Connect-LMAccount function to log in before running this command.
+#>
+Function Set-LMAccessGroup {
+
+    [CmdletBinding()]
+    Param (
+
+        [Parameter(ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
+        [Int]$Id,
+
+        [Parameter(ParameterSetName = 'Name')]
+        [String]$Name,
+
+        [String]$NewName,
+
+        [String]$Description,
+
+        [String]$Tenant
+
+    )
+    #Check if we are logged in and have valid api creds
+    Begin {}
+    Process {
+        If ($Script:LMAuth.Valid) {
+            #Lookup Group Id
+            If ($Name) {
+                $LookupResult = (Get-LMAccessGroup -Name $Name).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $Id = $LookupResult
+            }
+
+            If($PSItem){
+                $Message = "Id: $Id | Name: $($PSItem.name) | Description: $($PSItem.description)"
+            }
+            ElseIf($Name){
+                $Message = "Id: $Id | Name: $Name)"
+            }
+            Else{
+                $Message = "Id: $Id"
+            }
+                    
+            #Build header and uri
+            $ResourcePath = "/setting/accessgroup/$Id"
+
+            Try {
+                $Data = @{
+                    description                         = $Description
+                    name                                = $NewName
+                    tenantId                            = $Tenant
+                }
+
+                #Remove empty keys so we dont overwrite them
+                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+            
+                $Data = ($Data | ConvertTo-Json)
+
+                If ($PSCmdlet.ShouldProcess($Message, "Set AccessGroup")) {  
+                    $Headers = New-LMHeader -Auth $Script:LMAuth -Method "PATCH" -ResourcePath $ResourcePath -Data $Data
+                    $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+                    Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                    #Issue request
+                    $Response = Invoke-RestMethod -Uri $Uri -Method "PATCH" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                    Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.AccessGroup" )
+                }
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {}
+}

--- a/Public/Set-LMAppliesToFunction.ps1
+++ b/Public/Set-LMAppliesToFunction.ps1
@@ -46,7 +46,7 @@ Function Set-LMAppliesToFunction {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMAppliesToFunction.ps1
+++ b/Public/Set-LMAppliesToFunction.ps1
@@ -1,13 +1,13 @@
 Function Set-LMAppliesToFunction {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Name')]
         [String]$Name,
 
         [String]$NewName,
 
-        [Parameter(Mandatory, ParameterSetName = 'Id',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [String]$Id,
 
         [String]$Description,
@@ -31,18 +31,18 @@ Function Set-LMAppliesToFunction {
         #Build header and uri
         $ResourcePath = "/setting/functions/$Id"
 
-        If($PSItem){
+        If ($PSItem) {
             $Message = "Id: $Id | Name: $($PSItem.name)"
         }
-        Else{
+        Else {
             $Message = "Id: $Id"
         }
 
         Try {
             $Data = @{
-                name                                = $NewName
-                description                         = $Description
-                code                                = $AppliesTo
+                name        = $NewName
+                description = $Description
+                code        = $AppliesTo
             }
 
             #Remove empty keys so we dont overwrite them
@@ -56,7 +56,7 @@ Function Set-LMAppliesToFunction {
 
                 Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                    #Issue request
+                #Issue request
                 $Response = Invoke-RestMethod -Uri $Uri -Method "PATCH" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
                 Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.AppliesToFunction" )

--- a/Public/Set-LMCollector.ps1
+++ b/Public/Set-LMCollector.ps1
@@ -1,6 +1,6 @@
 Function Set-LMCollector {
 
-    [CmdletBinding(DefaultParameterSetName = 'Id',SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
 
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
@@ -54,13 +54,13 @@ Function Set-LMCollector {
             #Build header and uri
             $ResourcePath = "/setting/collector/collectors/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.hostname) | Description: $($PSItem.description)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 

--- a/Public/Set-LMCollector.ps1
+++ b/Public/Set-LMCollector.ps1
@@ -57,7 +57,7 @@ Function Set-LMCollector {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.hostname) | Description: $($PSItem.description)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
             Else {
@@ -82,7 +82,7 @@ Function Set-LMCollector {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMCollectorConfig.ps1
+++ b/Public/Set-LMCollectorConfig.ps1
@@ -95,7 +95,7 @@ Function Set-LMCollectorConfig {
     Begin {}
     Process {
         Function Process-CollectorConfig {
-            Param(
+            Param (
                 $Config,
                 $ConfLine,
                 $Value
@@ -104,7 +104,7 @@ Function Set-LMCollectorConfig {
             $Value = $Value.toString().toLower()
 
             $ConfigArray = $Config.Split([Environment]::NewLine)
-            [int[]]$Index = [Linq.Enumerable]::Range(0, $ConfigArray.Count).Where({ param($i) $ConfigArray[$i] -match $ConfLine })
+            [int[]]$Index = [Linq.Enumerable]::Range(0, $ConfigArray.Count).Where({ Param($i) $ConfigArray[$i] -match $ConfLine })
             If (($Index | Measure-Object).Count -eq 1) {
                 Write-LMHost "[INFO]: Updating config parameter $ConfLine to value $Value."
                 $ConfigArray[$Index[0]] = "$ConfLine=$Value"
@@ -134,9 +134,9 @@ Function Set-LMCollectorConfig {
                     $SnippetArray = [System.Collections.ArrayList]@()
                     $cmdName = $MyInvocation.InvocationName
                     $paramList = (Get-Command -Name $cmdName).Parameters
-                    foreach ( $key in $paramList.Keys ) {
+                    Foreach ( $key in $paramList.Keys ) {
                         $value = (Get-Variable $key -ErrorAction SilentlyContinue).Value
-                        if ( ($value -or $value -eq 0) -and ($key -ne "Id" -and $key -ne "Name" -and $key -ne "WaitForRestart") ) {
+                        If ( ($value -or $value -eq 0) -and ($key -ne "Id" -and $key -ne "Name" -and $key -ne "WaitForRestart") ) {
                             $SnippetArray.Add(@{$key = $value }) | Out-Null
                         }
                     }
@@ -173,7 +173,7 @@ Function Set-LMCollectorConfig {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.hostname) | Description: $($PSItem.description)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
             Else {
@@ -192,7 +192,7 @@ Function Set-LMCollectorConfig {
                 
                 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
                 
                 $Data = ($Data | ConvertTo-Json)
                 

--- a/Public/Set-LMCollectorConfig.ps1
+++ b/Public/Set-LMCollectorConfig.ps1
@@ -1,6 +1,6 @@
 Function Set-LMCollectorConfig {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
 
         [Parameter(ParameterSetName = 'Id-Conf', ValueFromPipelineByPropertyName)]
@@ -13,7 +13,7 @@ Function Set-LMCollectorConfig {
 
         [Parameter(ParameterSetName = 'Id-Conf')]
         [Parameter(ParameterSetName = 'Name-Conf')]
-        [ValidateSet("nano","small", "medium", "large", "extra_large", "double_extra_large")]
+        [ValidateSet("nano", "small", "medium", "large", "extra_large", "double_extra_large")]
         [String]$CollectorSize,
 
         [Parameter(ParameterSetName = 'Id-Conf')]
@@ -105,15 +105,15 @@ Function Set-LMCollectorConfig {
 
             $ConfigArray = $Config.Split([Environment]::NewLine)
             [int[]]$Index = [Linq.Enumerable]::Range(0, $ConfigArray.Count).Where({ param($i) $ConfigArray[$i] -match $ConfLine })
-            If(($Index | Measure-Object).Count -eq 1){
+            If (($Index | Measure-Object).Count -eq 1) {
                 Write-LMHost "[INFO]: Updating config parameter $ConfLine to value $Value."
-                $ConfigArray[$Index[0]]="$ConfLine=$Value"
+                $ConfigArray[$Index[0]] = "$ConfLine=$Value"
             }
-            Else{
-                Write-LMHost "[WARN]: Multiple matches found for config parameter $ConfLine, skipping processing."  -ForegroundColor Yellow
+            Else {
+                Write-LMHost "[WARN]: Multiple matches found for config parameter $ConfLine, skipping processing." -ForegroundColor Yellow
             }
             
-            Return ([string]::Join([Environment]::NewLine,$ConfigArray))
+            Return ([string]::Join([Environment]::NewLine, $ConfigArray))
         }
         
         If ($Script:LMAuth.Valid) {
@@ -127,67 +127,67 @@ Function Set-LMCollectorConfig {
                 $Id = $LookupResult
             }
             
-            If($PSCmdlet.ParameterSetName -like "*Snippet*"){
+            If ($PSCmdlet.ParameterSetName -like "*Snippet*") {
                 $CollectorConfData = (Get-LMCollector -Id $Id).collectorConf
                 
-                If($CollectorConfData){
+                If ($CollectorConfData) {
                     $SnippetArray = [System.Collections.ArrayList]@()
                     $cmdName = $MyInvocation.InvocationName
                     $paramList = (Get-Command -Name $cmdName).Parameters
                     foreach ( $key in $paramList.Keys ) {
                         $value = (Get-Variable $key -ErrorAction SilentlyContinue).Value
                         if ( ($value -or $value -eq 0) -and ($key -ne "Id" -and $key -ne "Name" -and $key -ne "WaitForRestart") ) {
-                            $SnippetArray.Add(@{$key = $value}) | Out-Null
+                            $SnippetArray.Add(@{$key = $value }) | Out-Null
                         }
                     }
                     
-                    Foreach ($Key in $SnippetArray.Keys){
-                        $CollectorConfData = Switch($Key){
-                            "SnmpThreadPool" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.snmp.threadpool" -Value $SnippetArray.$Key}
-                            "SnmpPduTimeout" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "snmp.pdu.timeout" -Value $SnippetArray.$Key}
-                            "ScriptThreadPool" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.script.threadpool" -Value $SnippetArray.$Key}
-                            "ScriptTimeout" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.script.timeout" -Value $SnippetArray.$Key}
-                            "BatchScriptThreadPool" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.batchscript.threadpool" -Value $SnippetArray.$Key}
-                            "BatchScriptTimeout" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.batchscript.timeout" -Value $SnippetArray.$Key}
-                            "PowerShellSPSEProcessCountMin" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "powershell.spse.process.count.min" -Value $SnippetArray.$Key}
-                            "PowerShellSPSEProcessCountMax" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "powershell.spse.process.count.max" -Value $SnippetArray.$Key}
-                            "NetflowEnable" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.enable" -Value $SnippetArray.$Key}
-                            "NbarEnable" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.nbar.enabled" -Value $SnippetArray.$Key}
-                            "NetflowPorts" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.ports" -Value $SnippetArray.$Key}
-                            "SflowPorts" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.sflow.ports" -Value $SnippetArray.$Key}
-                            "LMLogsSyslogEnable" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "lmlogs.syslog.enabled" -Value $SnippetArray.$Key}
-                            "LMLogsSyslogHostnameFormat" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "lmlogs.syslog.hostname.format" -Value $SnippetArray.$Key}
-                            "LMLogsSyslogPropertyName" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "lmlogs.syslog.property.name" -Value $SnippetArray.$Key}
-                            default {$CollectorConfData}
+                    Foreach ($Key in $SnippetArray.Keys) {
+                        $CollectorConfData = Switch ($Key) {
+                            "SnmpThreadPool" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.snmp.threadpool" -Value $SnippetArray.$Key }
+                            "SnmpPduTimeout" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "snmp.pdu.timeout" -Value $SnippetArray.$Key }
+                            "ScriptThreadPool" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.script.threadpool" -Value $SnippetArray.$Key }
+                            "ScriptTimeout" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.script.timeout" -Value $SnippetArray.$Key }
+                            "BatchScriptThreadPool" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.batchscript.threadpool" -Value $SnippetArray.$Key }
+                            "BatchScriptTimeout" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "collector.batchscript.timeout" -Value $SnippetArray.$Key }
+                            "PowerShellSPSEProcessCountMin" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "powershell.spse.process.count.min" -Value $SnippetArray.$Key }
+                            "PowerShellSPSEProcessCountMax" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "powershell.spse.process.count.max" -Value $SnippetArray.$Key }
+                            "NetflowEnable" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.enable" -Value $SnippetArray.$Key }
+                            "NbarEnable" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.nbar.enabled" -Value $SnippetArray.$Key }
+                            "NetflowPorts" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.ports" -Value $SnippetArray.$Key }
+                            "SflowPorts" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "netflow.sflow.ports" -Value $SnippetArray.$Key }
+                            "LMLogsSyslogEnable" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "lmlogs.syslog.enabled" -Value $SnippetArray.$Key }
+                            "LMLogsSyslogHostnameFormat" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "lmlogs.syslog.hostname.format" -Value $SnippetArray.$Key }
+                            "LMLogsSyslogPropertyName" { Process-CollectorConfig -Config $CollectorConfData -ConfLine "lmlogs.syslog.property.name" -Value $SnippetArray.$Key }
+                            default { $CollectorConfData }
                         }
                     }
                 }
             }
-            Else{
+            Else {
                 $CollectorConfData = $CollectorConf
             }
             
             #Build header and uri
             $ResourcePath = "/setting/collector/collectors/$Id/services/restart"
             
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.hostname) | Description: $($PSItem.description)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
             
             Try {
                 $Data = @{
-                    collectorSize                   = $CollectorSize
-                    collectorConf                   = $CollectorConfData
-                    sbproxyConf                     = $SbproxyConf
-                    watchdogConf                    = $WatchdogConf
-                    websiteConf                     = $WebsiteConf
-                    wrapperConf                     = $WrapperConf
+                    collectorSize = $CollectorSize
+                    collectorConf = $CollectorConfData
+                    sbproxyConf   = $SbproxyConf
+                    watchdogConf  = $WatchdogConf
+                    websiteConf   = $WebsiteConf
+                    wrapperConf   = $WrapperConf
                 }
                 
                 
@@ -197,7 +197,7 @@ Function Set-LMCollectorConfig {
                 $Data = ($Data | ConvertTo-Json)
                 
                 If ($PSCmdlet.ShouldProcess($Message, "Set Collector Config ")) {  
-                    Write-LMHost "[WARN]: This command will restart the targeted collector on update of the configuration"  -ForegroundColor Yellow
+                    Write-LMHost "[WARN]: This command will restart the targeted collector on update of the configuration" -ForegroundColor Yellow
                     $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data
                     $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
                     
@@ -206,28 +206,28 @@ Function Set-LMCollectorConfig {
                     #Issue request
                     $Response = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
-                    If($WaitForRestart){
+                    If ($WaitForRestart) {
                         $JobStarted = $false
                         $Tries = 0
-                        While(!$JobStarted -or $Tries -eq 5){
+                        While (!$JobStarted -or $Tries -eq 5) {
                             #Build header and uri
                             $ResourcePath = "/setting/collector/collectors/$Id/services/restart/$Response"
                             $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
                             $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
         
                             $SubmitResponse = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
-                            If($SubmitResponse.errorMessage -eq "The task is still running"){
+                            If ($SubmitResponse.errorMessage -eq "The task is still running") {
                                 Write-LMHost "[INFO]: The task is still running..."
                                 Start-Sleep -Seconds 2
                                 $Tries++
                             }
-                            Else{
+                            Else {
                                 $JobStarted = $true
                             }
                         }
                         Return "Job status code: $($SubmitResponse.jobStatus), Job message: $($SubmitResponse.jobErrmsg)"
                     }
-                    Else{
+                    Else {
                         Return "Successfully submitted restart request(jobID:$Response) with updated configurations. Collector will restart once the request has been picked up."
                     }
                 }

--- a/Public/Set-LMCollectorGroup.ps1
+++ b/Public/Set-LMCollectorGroup.ps1
@@ -1,6 +1,6 @@
 Function Set-LMCollectorGroup {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
 
         [Parameter(ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
@@ -44,24 +44,24 @@ Function Set-LMCollectorGroup {
             #Build header and uri
             $ResourcePath = "/setting/collector/groups/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | Description: $($PSItem.description)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
             Try {
                 $Data = @{
-                    description                         = $Description
-                    name                                = $NewName
-                    collectorGroupId                    = $CollectorGroupId
-                    customProperties                    = $customProperties
-                    autoBalance                         = $AutoBalance
-                    autoBalanceInstanceCountThreshold   = $AutoBalanceInstanceCountThreshold
+                    description                       = $Description
+                    name                              = $NewName
+                    collectorGroupId                  = $CollectorGroupId
+                    customProperties                  = $customProperties
+                    autoBalance                       = $AutoBalance
+                    autoBalanceInstanceCountThreshold = $AutoBalanceInstanceCountThreshold
                 }
 
             

--- a/Public/Set-LMCollectorGroup.ps1
+++ b/Public/Set-LMCollectorGroup.ps1
@@ -47,7 +47,7 @@ Function Set-LMCollectorGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | Description: $($PSItem.description)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
             Else {
@@ -66,7 +66,7 @@ Function Set-LMCollectorGroup {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMConfigsource.ps1
+++ b/Public/Set-LMConfigsource.ps1
@@ -44,7 +44,7 @@ Function Set-LMConfigsource {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {
@@ -63,7 +63,7 @@ Function Set-LMConfigsource {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMConfigsource.ps1
+++ b/Public/Set-LMConfigsource.ps1
@@ -1,6 +1,6 @@
 Function Set-LMConfigsource {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [String]$Id,
@@ -18,7 +18,7 @@ Function Set-LMConfigsource {
 
         [String]$TechNotes,
 
-        [ValidateSet("3600","14400","28800","86400")]
+        [ValidateSet("3600", "14400", "28800", "86400")]
         [String]$PollingIntervalInSeconds, #In Seconds
 
         [PSCustomObject]$ConfigChecks #Should be the full datapoints object from the output of Get-LMDatasource
@@ -41,25 +41,25 @@ Function Set-LMConfigsource {
             #Build header and uri
             $ResourcePath = "/setting/configsources/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
             Try {
                 $Data = @{
-                    name                      = $NewName
-                    displayName               = $DisplayName
-                    description               = $Description
-                    appliesTo                 = $appliesTo
-                    technology                = $TechNotes
-                    collectInterval           = $PollingIntervalInSeconds
-                    configChecks              = $ConfigChecks
+                    name            = $NewName
+                    displayName     = $DisplayName
+                    description     = $Description
+                    appliesTo       = $appliesTo
+                    technology      = $TechNotes
+                    collectInterval = $PollingIntervalInSeconds
+                    configChecks    = $ConfigChecks
                 }
 
                 #Remove empty keys so we dont overwrite them

--- a/Public/Set-LMDatasource.ps1
+++ b/Public/Set-LMDatasource.ps1
@@ -1,6 +1,6 @@
 Function Set-LMDatasource {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [String]$Id,
@@ -40,25 +40,25 @@ Function Set-LMDatasource {
             #Build header and uri
             $ResourcePath = "/setting/datasources/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 
             Try {
                 $Data = @{
-                    name                      = $NewName
-                    displayName               = $DisplayName
-                    description               = $Description
-                    appliesTo                 = $appliesTo
-                    technology                = $TechNotes
-                    collectInterval           = $PollingIntervalInSeconds
-                    dataPoints                = $Datapoints
+                    name            = $NewName
+                    displayName     = $DisplayName
+                    description     = $Description
+                    appliesTo       = $appliesTo
+                    technology      = $TechNotes
+                    collectInterval = $PollingIntervalInSeconds
+                    dataPoints      = $Datapoints
                 }
 
                 #Remove empty keys so we dont overwrite them

--- a/Public/Set-LMDatasource.ps1
+++ b/Public/Set-LMDatasource.ps1
@@ -43,7 +43,7 @@ Function Set-LMDatasource {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {
@@ -62,7 +62,7 @@ Function Set-LMDatasource {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMDevice.ps1
+++ b/Public/Set-LMDevice.ps1
@@ -1,6 +1,6 @@
 Function Set-LMDevice {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
         [String]$Id,
@@ -64,13 +64,13 @@ Function Set-LMDevice {
             #Build header and uri
             $ResourcePath = "/device/devices/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 

--- a/Public/Set-LMDevice.ps1
+++ b/Public/Set-LMDevice.ps1
@@ -67,7 +67,7 @@ Function Set-LMDevice {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | DisplayName: $($PSItem.displayName)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name"
             }
             Else {
@@ -94,7 +94,7 @@ Function Set-LMDevice {
 
                 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMDeviceDatasourceInstance.ps1
+++ b/Public/Set-LMDeviceDatasourceInstance.ps1
@@ -1,3 +1,61 @@
+<#
+.SYNOPSIS
+Sets the properties of a LogicMonitor device datasource instance.
+
+.DESCRIPTION
+The Set-LMDeviceDatasourceInstance function is used to set the properties of a LogicMonitor device datasource instance. It allows you to update the display name, wild values, description, custom properties, monitoring and alerting settings, and instance group ID of the specified instance.
+
+.PARAMETER DisplayName
+Specifies the new display name for the instance.
+
+.PARAMETER WildValue
+Specifies the first wild value for the instance.
+
+.PARAMETER WildValue2
+Specifies the second wild value for the instance.
+
+.PARAMETER Description
+Specifies the description for the instance.
+
+.PARAMETER Properties
+Specifies a hashtable of custom properties for the instance.
+
+.PARAMETER StopMonitoring
+Specifies whether to stop monitoring the instance. This parameter accepts $true or $false.
+
+.PARAMETER DisableAlerting
+Specifies whether to disable alerting for the instance. This parameter accepts $true or $false.
+
+.PARAMETER InstanceGroupId
+Specifies the ID of the instance group to which the instance belongs.
+
+.PARAMETER InstanceId
+Specifies the ID of the instance to update. This parameter is mandatory and can be provided via pipeline.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource associated with the instance. This parameter is mandatory when using the 'Name-dsName' parameter set.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource associated with the instance. This parameter is mandatory when using the 'Id-dsId' or 'Name-dsId' parameter set.
+
+.PARAMETER Id
+Specifies the ID of the device associated with the instance. This parameter is mandatory when using the 'Id-dsId' or 'Id-dsName' parameter set. This parameter can also be specified using the 'DeviceId' alias.
+
+.PARAMETER Name
+Specifies the name of the device associated with the instance. This parameter is mandatory when using the 'Name-dsName' or 'Name-dsId' parameter set. This parameter can also be specified using the 'DeviceName' alias.
+
+.EXAMPLE
+Set-LMDeviceDatasourceInstance -InstanceId 12345 -DisplayName "New Instance Name" -Description "Updated instance description"
+
+This example sets the display name and description of the instance with ID 12345.
+
+.EXAMPLE
+Get-LMDevice -Name "MyDevice" | Set-LMDeviceDatasourceInstance -DatasourceName "MyDatasource" -DisplayName "New Instance Name"
+
+This example retrieves the device with the name "MyDevice" and sets the display name of the instance associated with the datasource "MyDatasource".
+
+#>
+
 Function Set-LMDeviceDatasourceInstance {
 
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
@@ -19,7 +77,6 @@ Function Set-LMDeviceDatasourceInstance {
         [String]$InstanceGroupId,
         
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-        [Alias("Id")]
         [String]$InstanceId,
 
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
@@ -32,11 +89,13 @@ Function Set-LMDeviceDatasourceInstance {
     
         [Parameter(Mandatory, ParameterSetName = 'Id-dsId', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
-        [String]$DeviceId,
+        [Alias('DeviceId')]
+        [String]$Id,
     
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
-        [String]$DeviceName
+        [Alias('DeviceName')]
+        [String]$Name
 
     )
 
@@ -46,17 +105,17 @@ Function Set-LMDeviceDatasourceInstance {
         If ($Script:LMAuth.Valid) {
 
             #Lookup Device Id
-            If ($DeviceName) {
-                $LookupResult = (Get-LMDevice -Name $DeviceName).Id
-                If (Test-LookupResult -Result $LookupResult -LookupString $DeviceName) {
+            If ($Name) {
+                $LookupResult = (Get-LMDevice -Name $Name).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
                     return
                 }
-                $DeviceId = $LookupResult
+                $Id = $LookupResult
             }
 
             #Lookup DatasourceId
             If ($DatasourceName -or $DatasourceId) {
-                $LookupResult = (Get-LMDeviceDataSourceList -Id $DeviceId | Where-Object { $_.dataSourceName -eq $DatasourceName -or $_.dataSourceId -eq $DatasourceId }).Id
+                $LookupResult = (Get-LMDeviceDataSourceList -Id $Id | Where-Object { $_.dataSourceName -eq $DatasourceName -or $_.dataSourceId -eq $DatasourceId }).Id
                 If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceName) {
                     return
                 }
@@ -72,16 +131,16 @@ Function Set-LMDeviceDatasourceInstance {
             }
             
             #Build header and uri
-            $ResourcePath = "/device/devices/$DeviceId/devicedatasources/$HdsId/instances/$instanceId"
+            $ResourcePath = "/device/devices/$Id/devicedatasources/$HdsId/instances/$instanceId"
 
             If ($PSItem) {
                 $Message = "deviceDisplayName: $($PSItem.deviceDisplayName) | instanceId: $($PSItem.id) | instanceName: $($PSItem.name)"
             }
-            Elseif ($DeviceName) {
-                $Message = "deviceDisplayName: $DeviceName | instanceId: $InstanceId"
+            Elseif ($Name) {
+                $Message = "deviceDisplayName: $Name | instanceId: $InstanceId"
             }
             Else {
-                $Message = "instanceId: $InstanceId | deviceId: $DeviceId"
+                $Message = "instanceId: $InstanceId | Id: $Id"
             }
 
             Try {

--- a/Public/Set-LMDeviceDatasourceInstance.ps1
+++ b/Public/Set-LMDeviceDatasourceInstance.ps1
@@ -77,7 +77,7 @@ Function Set-LMDeviceDatasourceInstance {
             If ($PSItem) {
                 $Message = "deviceDisplayName: $($PSItem.deviceDisplayName) | instanceId: $($PSItem.id) | instanceName: $($PSItem.name)"
             }
-            ElseIf ($DeviceName) {
+            Elseif ($DeviceName) {
                 $Message = "deviceDisplayName: $DeviceName | instanceId: $InstanceId"
             }
             Else {
@@ -97,7 +97,7 @@ Function Set-LMDeviceDatasourceInstance {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMDeviceDatasourceInstance.ps1
+++ b/Public/Set-LMDeviceDatasourceInstance.ps1
@@ -1,6 +1,6 @@
 Function Set-LMDeviceDatasourceInstance {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [String]$DisplayName,
         
@@ -40,8 +40,8 @@ Function Set-LMDeviceDatasourceInstance {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -74,13 +74,13 @@ Function Set-LMDeviceDatasourceInstance {
             #Build header and uri
             $ResourcePath = "/device/devices/$DeviceId/devicedatasources/$HdsId/instances/$instanceId"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "deviceDisplayName: $($PSItem.deviceDisplayName) | instanceId: $($PSItem.id) | instanceName: $($PSItem.name)"
             }
-            ElseIf($DeviceName){
+            ElseIf ($DeviceName) {
                 $Message = "deviceDisplayName: $DeviceName | instanceId: $InstanceId"
             }
-            Else{
+            Else {
                 $Message = "instanceId: $InstanceId | deviceId: $DeviceId"
             }
 
@@ -124,5 +124,5 @@ Function Set-LMDeviceDatasourceInstance {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -1,6 +1,6 @@
 Function Set-LMDeviceDatasourceInstanceAlertSetting {
 
-    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
         [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
@@ -47,8 +47,8 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
         [Int]$AlertForNoData
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -72,14 +72,14 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
 
             #Lookup HdsiId
             If ($DatasourceName) {
-                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id
+                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id
                 If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                     return
                 }
                 $HdsiId = $LookupResult
             }
-            Else{
-                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName"}).Id
+            Else {
+                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id
                 If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                     return
                 }
@@ -88,14 +88,14 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
 
             #Lookup HdsiId
             If ($DatapointName) {
-                $LookupResult = (Get-LMDeviceDatasourceInstanceAlertSetting -DatasourceName $DatasourceName -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName}).Id
+                $LookupResult = (Get-LMDeviceDatasourceInstanceAlertSetting -DatasourceName $DatasourceName -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName }).Id
                 If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                     return
                 }
                 $DatapointId = $LookupResult
             }
-            Else{
-                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName}).Id
+            Else {
+                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName }).Id
                 If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
                     return
                 }
@@ -109,13 +109,13 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
 
             Try {
                 $Data = @{
-                    disableAlerting      = $DisableAlerting
-                    alertExprNote        = $AlertExpressionNote
-                    alertExpr            = $AlertExpression
-                    alertClearTransitionInterval    = $AlertClearTransitionInterval
-                    alertClearInterval              = $AlertClearTransitionInterval
-                    alertTransitionInterval         = $AlertTransitionInterval
-                    alertForNoData                  = $AlertForNoData
+                    disableAlerting              = $DisableAlerting
+                    alertExprNote                = $AlertExpressionNote
+                    alertExpr                    = $AlertExpression
+                    alertClearTransitionInterval = $AlertClearTransitionInterval
+                    alertClearInterval           = $AlertClearTransitionInterval
+                    alertTransitionInterval      = $AlertTransitionInterval
+                    alertForNoData               = $AlertForNoData
                 }
 
                 #Remove empty keys so we dont overwrite them
@@ -145,5 +145,5 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -70,6 +70,9 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
                 $HdsId = $LookupResult
             }
 
+            #Replace brakets in instance name
+            $InstanceName = $InstanceName -replace "[\[\]]", "?"
+
             #Lookup HdsiId
             If ($DatasourceName) {
                 $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id

--- a/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -119,7 +119,7 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "alertExpr" -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "alertExpr" -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
                 $Data = ($Data | ConvertTo-Json)
                 If ($PSCmdlet.ShouldProcess($Message, "Set Device Datasource Instance Alert Setting")) { 

--- a/Public/Set-LMDeviceGroup.ps1
+++ b/Public/Set-LMDeviceGroup.ps1
@@ -1,6 +1,6 @@
 Function Set-LMDeviceGroup {
 
-    [CmdletBinding(DefaultParameterSetName = "Id-ParentGroupId",SupportsShouldProcess,ConfirmImpact='None')]
+    [CmdletBinding(DefaultParameterSetName = "Id-ParentGroupId", SupportsShouldProcess, ConfirmImpact = 'None')]
     Param (
         [Parameter(Mandatory, ParameterSetName = 'Id-ParentGroupId', ValueFromPipelineByPropertyName)]
         [Parameter(Mandatory, ParameterSetName = 'Id-ParentGroupName')]
@@ -67,13 +67,13 @@ Function Set-LMDeviceGroup {
             #Build header and uri
             $ResourcePath = "/device/groups/$Id"
 
-            If($PSItem){
+            If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | Path: $($PSItem.fullPath)"
             }
-            ElseIf($Name){
+            ElseIf ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
-            Else{
+            Else {
                 $Message = "Id: $Id"
             }
 

--- a/Public/Set-LMDeviceGroup.ps1
+++ b/Public/Set-LMDeviceGroup.ps1
@@ -70,7 +70,7 @@ Function Set-LMDeviceGroup {
             If ($PSItem) {
                 $Message = "Id: $Id | Name: $($PSItem.name) | Path: $($PSItem.fullPath)"
             }
-            ElseIf ($Name) {
+            Elseif ($Name) {
                 $Message = "Id: $Id | Name: $Name)"
             }
             Else {
@@ -89,7 +89,7 @@ Function Set-LMDeviceGroup {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMDeviceGroupDatasourceAlertSetting.ps1
+++ b/Public/Set-LMDeviceGroupDatasourceAlertSetting.ps1
@@ -92,7 +92,7 @@ Function Set-LMDeviceGroupDatasourceAlertSetting {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($dpConfig.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($dpConfig[$_]) -and $_ -ne "alertExpr" -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $dpConfig.Remove($_) } }
+                @($dpConfig.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($dpConfig[$_]) -and $_ -ne "alertExpr" -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $dpConfig.Remove($_) } }
 
                 $Data = @{
                     dpConfig = @($dpConfig)

--- a/Public/Set-LMDeviceGroupDatasourceAlertSetting.ps1
+++ b/Public/Set-LMDeviceGroupDatasourceAlertSetting.ps1
@@ -43,8 +43,8 @@ Function Set-LMDeviceGroupDatasourceAlertSetting {
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -68,7 +68,7 @@ Function Set-LMDeviceGroupDatasourceAlertSetting {
 
             #Lookup DatapointId
             If ($DatapointName) {
-                $LookupResult = (Get-LMDeviceGroupDatasourceAlertSetting -Id $Id -DatasourceId $DatasourceId | Where-Object {$_.dataPointName -eq $DatapointName}).dataPointId
+                $LookupResult = (Get-LMDeviceGroupDatasourceAlertSetting -Id $Id -DatasourceId $DatasourceId | Where-Object { $_.dataPointName -eq $DatapointName }).dataPointId
                 If (Test-LookupResult -Result $LookupResult -LookupString $DatapointName) {
                     return
                 }
@@ -80,14 +80,14 @@ Function Set-LMDeviceGroupDatasourceAlertSetting {
 
             Try {
                 $dpConfig = @{
-                    disableAlerting                 = $DisableAlerting
-                    dataPointId                     = $DatapointId
-                    dataPointName                   = $DatapointName
-                    alertExprNote                   = $AlertExpressionNote
-                    alertExpr                       = $AlertExpression
-                    alertClearTransitionInterval    = $AlertClearTransitionInterval
-                    alertTransitionInterval         = $AlertTransitionInterval
-                    alertForNoData                  = $AlertForNoData
+                    disableAlerting              = $DisableAlerting
+                    dataPointId                  = $DatapointId
+                    dataPointName                = $DatapointName
+                    alertExprNote                = $AlertExpressionNote
+                    alertExpr                    = $AlertExpression
+                    alertClearTransitionInterval = $AlertClearTransitionInterval
+                    alertTransitionInterval      = $AlertTransitionInterval
+                    alertForNoData               = $AlertForNoData
 
                 }
 
@@ -120,5 +120,5 @@ Function Set-LMDeviceGroupDatasourceAlertSetting {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMDeviceProperty.ps1
+++ b/Public/Set-LMDeviceProperty.ps1
@@ -15,8 +15,8 @@ Function Set-LMDeviceProperty {
         [String]$PropertyValue
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -59,5 +59,5 @@ Function Set-LMDeviceProperty {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMNetScan.ps1
+++ b/Public/Set-LMNetScan.ps1
@@ -109,7 +109,7 @@ Function Set-LMNetscan {
 
                 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
                 
                 $Data = ($Data | ConvertTo-Json)
                 $Headers = New-LMHeader -Auth $Script:LMAuth -Method "PATCH" -ResourcePath $ResourcePath -Data $Data

--- a/Public/Set-LMNetscanGroup.ps1
+++ b/Public/Set-LMNetscanGroup.ps1
@@ -33,8 +33,8 @@ Function Set-LMNetscanGroup {
 
             Try {
                 $Data = @{
-                    description                         = $Description
-                    name                                = $NewName
+                    description = $Description
+                    name        = $NewName
                 }
 
             

--- a/Public/Set-LMNetscanGroup.ps1
+++ b/Public/Set-LMNetscanGroup.ps1
@@ -39,7 +39,7 @@ Function Set-LMNetscanGroup {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMNewUserMessage.ps1
+++ b/Public/Set-LMNewUserMessage.ps1
@@ -20,8 +20,8 @@ Function Set-LMNewUserMessage {
 
             Try {
                 $Data = @{
-                    messageBody                         = $MessageBody
-                    messageSubject                      = $MessageSubject
+                    messageBody    = $MessageBody
+                    messageSubject = $MessageSubject
                 }
 
                 #Remove empty keys so we dont overwrite them

--- a/Public/Set-LMNewUserMessage.ps1
+++ b/Public/Set-LMNewUserMessage.ps1
@@ -25,7 +25,7 @@ Function Set-LMNewUserMessage {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMOpsNote.ps1
+++ b/Public/Set-LMOpsNote.ps1
@@ -72,7 +72,7 @@ Function Set-LMOpsNote {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
                 If ($ClearTags) {
                     $Data.tags = @()

--- a/Public/Set-LMOpsNote.ps1
+++ b/Public/Set-LMOpsNote.ps1
@@ -20,43 +20,43 @@ Function Set-LMOpsNote {
         [String[]]$DeviceIds
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
-            If($NoteDate){
+            If ($NoteDate) {
                 $Epoch = Get-Date -Date "01/01/1970"
                 [int64]$NoteDate = (New-TimeSpan -Start $Epoch -End $NoteDate.ToUniversalTime()).TotalSeconds
             }
 
             $Scope = @()
-            If($ResourceIds -or $WebsiteIds -or $DeviceGroupIds){
-                Foreach($deviceId in $DeviceIds){
+            If ($ResourceIds -or $WebsiteIds -or $DeviceGroupIds) {
+                Foreach ($deviceId in $DeviceIds) {
                     $Scope += [PSCustomObject]@{
-                        type = "device"
-                        groupId = "0"
+                        type     = "device"
+                        groupId  = "0"
                         deviceId = $deviceId
                     }
                 }
-                Foreach($websiteId in $WebsiteIds){
+                Foreach ($websiteId in $WebsiteIds) {
                     $Scope += [PSCustomObject]@{
-                        type = "website"
-                        groupId = "0"
+                        type      = "website"
+                        groupId   = "0"
                         websiteId = $websiteId
                     }
                 }
-                Foreach($groupId in $DeviceGroupIds){
+                Foreach ($groupId in $DeviceGroupIds) {
                     $Scope += @{
-                        type = "deviceGroup"
+                        type    = "deviceGroup"
                         groupId = $groupId
                     }
                 }
             }
 
             $TagList = @()
-            Foreach($tag in $Tags){
-                $TagList += @{name = $tag}
+            Foreach ($tag in $Tags) {
+                $TagList += @{name = $tag }
             }
 
 
@@ -74,7 +74,7 @@ Function Set-LMOpsNote {
                 #Remove empty keys so we dont overwrite them
                 @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
-                If($ClearTags){
+                If ($ClearTags) {
                     $Data.tags = @()
                 }
 
@@ -101,5 +101,5 @@ Function Set-LMOpsNote {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMPortalInfo.ps1
+++ b/Public/Set-LMPortalInfo.ps1
@@ -40,7 +40,7 @@ Function Set-LMPortalInfo {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
             If ($ClearWhitelist) {
                 $Data.whitelist = ""

--- a/Public/Set-LMPortalInfo.ps1
+++ b/Public/Set-LMPortalInfo.ps1
@@ -16,13 +16,13 @@ Function Set-LMPortalInfo {
 
         [String]$CompanyDisplayName,
 
-        [ValidateSet(30,60,120,240,480,1440,10080,43200)]
+        [ValidateSet(30, 60, 120, 240, 480, 1440, 10080, 43200)]
         [Nullable[Int]]$UserSessionTimeoutInMin
 
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
             
@@ -30,19 +30,19 @@ Function Set-LMPortalInfo {
             $ResourcePath = "/setting/companySetting"
 
             $Data = @{
-                whiteList   = $Whitelist
-                sessionTimeoutInSeconds   = $UserSessionTimeoutInMin * 60
-                requireTwoFA   = $RequireTwoFA
-                alertTotalIncludeInAck   = $IncludeACKinAlertTotals
-                alertTotalIncludeInSdt   = $IncludeSDTinAlertTotals
-                companyDisplayName   = $CompanyDisplayName
-                enableRemoteSession   = $EnableRemoteSession
+                whiteList               = $Whitelist
+                sessionTimeoutInSeconds = $UserSessionTimeoutInMin * 60
+                requireTwoFA            = $RequireTwoFA
+                alertTotalIncludeInAck  = $IncludeACKinAlertTotals
+                alertTotalIncludeInSdt  = $IncludeSDTinAlertTotals
+                companyDisplayName      = $CompanyDisplayName
+                enableRemoteSession     = $EnableRemoteSession
             }
 
             #Remove empty keys so we dont overwrite them
             @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
-            If($ClearWhitelist){
+            If ($ClearWhitelist) {
                 $Data.whitelist = ""
             }
 
@@ -70,5 +70,5 @@ Function Set-LMPortalInfo {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMPropertysource.ps1
+++ b/Public/Set-LMPropertysource.ps1
@@ -53,7 +53,7 @@ Function Set-LMPropertysource {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMPropertysource.ps1
+++ b/Public/Set-LMPropertysource.ps1
@@ -43,13 +43,13 @@ Function Set-LMPropertysource {
 
             Try {
                 $Data = @{
-                    name                      = $NewName
-                    description               = $Description
-                    appliesTo                 = $appliesTo
-                    technology                = $TechNotes
-                    group                     = $Group
-                    groovyScript              = $Script
-                    scriptType                = $ScriptType
+                    name         = $NewName
+                    description  = $Description
+                    appliesTo    = $appliesTo
+                    technology   = $TechNotes
+                    group        = $Group
+                    groovyScript = $Script
+                    scriptType   = $ScriptType
                 }
 
                 #Remove empty keys so we dont overwrite them

--- a/Public/Set-LMPushModuleDeviceProperty.ps1
+++ b/Public/Set-LMPushModuleDeviceProperty.ps1
@@ -15,8 +15,8 @@ Function Set-LMPushModuleDeviceProperty {
         [String]$PropertyValue
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -33,8 +33,8 @@ Function Set-LMPushModuleDeviceProperty {
 
             Try {
                 $Data = @{
-                    resourceIds = @{"system.deviceid"=$Id}
-                    resourceProperties = @{$PropertyName=$PropertyValue}
+                    resourceIds        = @{"system.deviceid" = $Id }
+                    resourceProperties = @{$PropertyName = $PropertyValue }
                 }
 
                 $Data = ($Data | ConvertTo-Json)
@@ -60,5 +60,5 @@ Function Set-LMPushModuleDeviceProperty {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMPushModuleInstanceProperty.ps1
+++ b/Public/Set-LMPushModuleInstanceProperty.ps1
@@ -21,8 +21,8 @@ Function Set-LMPushModuleInstanceProperty {
         [String]$PropertyValue
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -39,10 +39,10 @@ Function Set-LMPushModuleInstanceProperty {
 
             Try {
                 $Data = @{
-                    resourceIds = @{"system.deviceid"=$DeviceId}
-                    instanceName = $InstanceName
-                    dataSource = $DataSourceName
-                    instanceProperties = @{$PropertyName=$PropertyValue}
+                    resourceIds        = @{"system.deviceid" = $DeviceId }
+                    instanceName       = $InstanceName
+                    dataSource         = $DataSourceName
+                    instanceProperties = @{$PropertyName = $PropertyValue }
                 }
 
                 $Data = ($Data | ConvertTo-Json)
@@ -68,5 +68,5 @@ Function Set-LMPushModuleInstanceProperty {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMReportGroup.ps1
+++ b/Public/Set-LMReportGroup.ps1
@@ -38,7 +38,7 @@ Function Set-LMReportGroup {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMReportGroup.ps1
+++ b/Public/Set-LMReportGroup.ps1
@@ -32,8 +32,8 @@ Function Set-LMReportGroup {
 
             Try {
                 $Data = @{
-                    description                         = $Description
-                    name                                = $NewName
+                    description = $Description
+                    name        = $NewName
                 }
 
             

--- a/Public/Set-LMRole.ps1
+++ b/Public/Set-LMRole.ps1
@@ -2,12 +2,12 @@ Function Set-LMRole {
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     Param (
-        [Parameter(Mandatory,ParameterSetName = 'Id-Custom', ValueFromPipelineByPropertyName)]
-        [Parameter(Mandatory,ParameterSetName = 'Id-Default', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Id-Custom', ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ParameterSetName = 'Id-Default', ValueFromPipelineByPropertyName)]
         [String]$Id,
 
-        [Parameter(Mandatory,ParameterSetName = 'Name-Custom')]
-        [Parameter(Mandatory,ParameterSetName = 'Name-Default')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-Custom')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-Default')]
         [String]$Name,
 
         [Parameter(ParameterSetName = 'Id-Custom')]
@@ -54,47 +54,47 @@ Function Set-LMRole {
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$DashboardsPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$ResourcePermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view","manage","commit","publish","none")]
+        [ValidateSet("view", "manage", "commit", "publish", "none")]
         [String]$LMXToolBoxPermission = "none",
         
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view","install","none")]
+        [ValidateSet("view", "install", "none")]
         [String]$LMXPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$LogsPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$WebsitesPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$SavedMapsPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none")]
+        [ValidateSet("view", "manage", "none")]
         [String]$ReportsPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
         [Parameter(ParameterSetName = 'Id-Default')]
-        [ValidateSet("view", "manage","none","manage-collectors","view-collectors")]
+        [ValidateSet("view", "manage", "none", "manage-collectors", "view-collectors")]
         [String]$SettingsPermission = "none",
 
         [Parameter(ParameterSetName = 'Name-Default')]
@@ -129,8 +129,8 @@ Function Set-LMRole {
         [Parameter(ParameterSetName = 'Id-Default')]
         [Switch]$EnableRemoteSessionForResources,
 
-        [Parameter(Mandatory,ParameterSetName = 'Name-Custom')]
-        [Parameter(Mandatory,ParameterSetName = 'Id-Custom')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-Custom')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-Custom')]
         [PSCustomObject]$CustomPrivilegesObject
 
     )
@@ -150,197 +150,197 @@ Function Set-LMRole {
         $ResourcePath = "/setting/roles/$Id"
         $Privileges = @()
 
-        If(!$CustomPrivilegesObject){
+        If (!$CustomPrivilegesObject) {
 
-            If($ViewTraces){
+            If ($ViewTraces) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "tracesManageTab"
-                    operation = "read"
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "tracesManageTab"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
 
-            If($EnableRemoteSessionForResources){
+            If ($EnableRemoteSessionForResources) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "remoteSession"
-                    operation = "write"
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "remoteSession"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($AllowedToViewMapsTab){
+            If ($AllowedToViewMapsTab) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "resourceMapTab"
-                    operation = "read"
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "resourceMapTab"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
 
-            If($AllowWidgetSharing){
+            If ($AllowWidgetSharing) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "sharingwidget"
-                    objectName = "sharingwidget"
-                    objectType = "dashboard_group"
-                    operation = "write"
+                    objectId     = "sharingwidget"
+                    objectName   = "sharingwidget"
+                    objectType   = "dashboard_group"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($CreatePrivateDashboards){
+            If ($CreatePrivateDashboards) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "private"
-                    objectName = "private"
-                    objectType = "dashboard_group"
-                    operation = "write"
+                    objectId     = "private"
+                    objectName   = "private"
+                    objectType   = "dashboard_group"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($LMXToolBoxPermission){
+            If ($LMXToolBoxPermission) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "allinstalledmodules"
+                    objectId   = "allinstalledmodules"
                     objectName = "All installed modules"
                     objectType = "module"
-                    operation = $LMXToolBoxPermission
+                    operation  = $LMXToolBoxPermission
                 }
             }
 
-            If($LMXPermission){
+            If ($LMXPermission) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "All exchange modules"
+                    objectId   = "All exchange modules"
                     objectName = "private"
                     objectType = "module"
-                    operation = $LMXPermission
+                    operation  = $LMXPermission
                 }
             }
             
-            If($ViewSupport){
+            If ($ViewSupport) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "chat"
-                    objectName = "help"
-                    objectType = "help"
-                    operation = "write"
+                    objectId     = "chat"
+                    objectName   = "help"
+                    objectType   = "help"
+                    operation    = "write"
                     subOperation = ""
                 }
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "help"
-                    objectType = "help"
-                    operation = "read"
-                    subOperation = ""
-                }
-            }
-
-            If($ConfigTabRequiresManagePermission){
-                $Privileges += [PSCustomObject]@{
-                    objectId = ""
-                    objectName = "configNeedDeviceManagePermission"
-                    objectType = "configNeedDeviceManagePermission"
-                    operation = "write"
+                    objectId     = "*"
+                    objectName   = "help"
+                    objectType   = "help"
+                    operation    = "read"
                     subOperation = ""
                 }
             }
 
-            If($AllowedToManageResourceDashboards){
+            If ($ConfigTabRequiresManagePermission) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = ""
-                    objectName = "deviceDashboard"
-                    objectType = "deviceDashboard"
-                    operation = "write"
+                    objectId     = ""
+                    objectName   = "configNeedDeviceManagePermission"
+                    objectType   = "configNeedDeviceManagePermission"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($DashboardsPermission -ne "none"){
+            If ($AllowedToManageResourceDashboards) {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "dashboard_group"
-                    operation = If($DashboardsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = ""
+                    objectName   = "deviceDashboard"
+                    objectType   = "deviceDashboard"
+                    operation    = "write"
                     subOperation = ""
                 }
             }
 
-            If($ResourcePermission -ne "none"){
+            If ($DashboardsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "host_group"
-                    operation = If($ResourcePermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "dashboard_group"
+                    operation    = If ($DashboardsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($LogsPermission -ne "none"){
+            If ($ResourcePermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "logs"
-                    operation = If($LogsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "host_group"
+                    operation    = If ($ResourcePermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($WebsitesPermission -ne "none"){
+            If ($LogsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "website_group"
-                    operation = If($WebsitesPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "logs"
+                    operation    = If ($LogsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($SavedMapsPermission -ne "none"){
+            If ($WebsitesPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "map"
-                    operation = If($SavedMapsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "website_group"
+                    operation    = If ($WebsitesPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($ReportsPermission -ne "none"){
+            If ($SavedMapsPermission -ne "none") {
                 $Privileges += [PSCustomObject]@{
-                    objectId = "*"
-                    objectName = "*"
-                    objectType = "report_group"
-                    operation = If($ReportsPermission -eq "manage"){"write"}Else{"read"}
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "map"
+                    operation    = If ($SavedMapsPermission -eq "manage") { "write" }Else { "read" }
                     subOperation = ""
                 }
             }
 
-            If($SettingsPermission -ne "none"){
-                If($SettingsPermission -ne "manage-collectors" -and $SettingsPermission -ne "view-collectors"){
+            If ($ReportsPermission -ne "none") {
+                $Privileges += [PSCustomObject]@{
+                    objectId     = "*"
+                    objectName   = "*"
+                    objectType   = "report_group"
+                    operation    = If ($ReportsPermission -eq "manage") { "write" }Else { "read" }
+                    subOperation = ""
+                }
+            }
+
+            If ($SettingsPermission -ne "none") {
+                If ($SettingsPermission -ne "manage-collectors" -and $SettingsPermission -ne "view-collectors") {
                     $Privileges += [PSCustomObject]@{
-                        objectId = "*"
-                        objectName = "*"
-                        objectType = "setting"
-                        operation = If($SettingsPermission -eq "manage"){"write"}Else{"read"}
+                        objectId     = "*"
+                        objectName   = "*"
+                        objectType   = "setting"
+                        operation    = If ($SettingsPermission -eq "manage") { "write" }Else { "read" }
                         subOperation = ""
                     }
 
                     $Privileges += [PSCustomObject]@{
-                        objectId = "useraccess.*"
-                        objectName = "useraccess.*"
-                        objectType = "setting"
-                        operation = If($ResourcePermission -eq "manage"){"write"}Else{"read"}
+                        objectId     = "useraccess.*"
+                        objectName   = "useraccess.*"
+                        objectType   = "setting"
+                        operation    = If ($ResourcePermission -eq "manage") { "write" }Else { "read" }
                         subOperation = ""
                     }
                 }
-                Else{
+                Else {
                     $Privileges += [PSCustomObject]@{
-                        objectId = "collectorgroup.*"
+                        objectId   = "collectorgroup.*"
                         objectName = "Collectors"
                         objectType = "setting"
-                        operation = If($SettingsPermission -eq "manage-collectors"){"write"}Else{"read"}
+                        operation  = If ($SettingsPermission -eq "manage-collectors") { "write" }Else { "read" }
                     }
                 }
             }
@@ -352,10 +352,10 @@ Function Set-LMRole {
                 customHelpURL   = $CustomHelpURL
                 description     = $Description
                 name            = $NewName
-                requireEULA      = If($RequireEULA.IsPresent){"true"}Else{""}
+                requireEULA     = If ($RequireEULA.IsPresent) { "true" }Else { "" }
                 roleGroupId     = $RoleGroupId
-                twoFARequired   = If($TwoFARequired.IsPresent){"true"}Else{""}
-                privileges      = If($CustomPrivilegesObject){$CustomPrivilegesObject}Else{$Privileges}
+                twoFARequired   = If ($TwoFARequired.IsPresent) { "true" }Else { "" }
+                privileges      = If ($CustomPrivilegesObject) { $CustomPrivilegesObject }Else { $Privileges }
             }
 
             #Remove empty keys so we dont overwrite them
@@ -367,7 +367,7 @@ Function Set-LMRole {
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
 
-                #Issue request
+            #Issue request
             $Response = Invoke-RestMethod -Uri $Uri -Method "PATCH" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
 
             Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Role" )

--- a/Public/Set-LMRole.ps1
+++ b/Public/Set-LMRole.ps1
@@ -359,7 +359,7 @@ Function Set-LMRole {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
             $Headers = New-LMHeader -Auth $Script:LMAuth -Method "PATCH" -ResourcePath $ResourcePath -Data $Data 

--- a/Public/Set-LMSDT.ps1
+++ b/Public/Set-LMSDT.ps1
@@ -73,7 +73,7 @@ Function Set-LMSDT {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMSDT.ps1
+++ b/Public/Set-LMSDT.ps1
@@ -1,6 +1,6 @@
 Function Set-LMSDT {
 
-    [CmdletBinding(DefaultParameterSetName="OneTime")]
+    [CmdletBinding(DefaultParameterSetName = "OneTime")]
     Param (
         [Parameter(Mandatory)]
         [String]$Id,
@@ -34,11 +34,11 @@ Function Set-LMSDT {
         [Nullable[Int]]$EndMinute,
 
         [Parameter(ParameterSetName = 'Recurring')]
-        [ValidateSet("Monday", "Tuesday", "Wednesday","Thursday","Friday","Saturday","Sunday")]
+        [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
         [String]$WeekDay,
 
         [Parameter(ParameterSetName = 'Recurring')]
-        [ValidateSet("First", "Second", "Third","Fourth","Last")]
+        [ValidateSet("First", "Second", "Third", "Fourth", "Last")]
         [String]$WeekOfMonth,
 
         [Parameter(ParameterSetName = 'Recurring')]
@@ -54,22 +54,22 @@ Function Set-LMSDT {
 
         Try {
             $Data = @{}
-            $Data.Add('comment',$Comment)
-            $Data.Add('hour',$StartHour)
-            $Data.Add('minute',$StartMinute)
-            $Data.Add('endHour',$EndHour)
-            $Data.Add('endMinute',$EndMinute)
-            $Data.Add('weekDay',$WeekDay)
-            $Data.Add('monthDay',$DayOfMonth)
-            $Data.Add('weekOfMonth',$WeekOfMonth)
+            $Data.Add('comment', $Comment)
+            $Data.Add('hour', $StartHour)
+            $Data.Add('minute', $StartMinute)
+            $Data.Add('endHour', $EndHour)
+            $Data.Add('endMinute', $EndMinute)
+            $Data.Add('weekDay', $WeekDay)
+            $Data.Add('monthDay', $DayOfMonth)
+            $Data.Add('weekOfMonth', $WeekOfMonth)
 
-            If($StartDate){
+            If ($StartDate) {
                 $StartDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $StartDate.ToUniversalTime()).TotalMilliseconds
-                $Data.Add('startDateTime',[math]::Round($StartDateTime))
+                $Data.Add('startDateTime', [math]::Round($StartDateTime))
             }
-            If($EndDate){
+            If ($EndDate) {
                 $EndDateTime = (New-TimeSpan -Start (Get-Date "01/01/1970") -End $EndDate.ToUniversalTime()).TotalMilliseconds
-                $Data.Add('endDateTime',[math]::Round($EndDateTime))
+                $Data.Add('endDateTime', [math]::Round($EndDateTime))
             }
 
             #Remove empty keys so we dont overwrite them

--- a/Public/Set-LMTopologysource.ps1
+++ b/Public/Set-LMTopologysource.ps1
@@ -52,7 +52,7 @@ Function Set-LMTopologysource {
                     name         = "script"
                 }
                 #Remove empty keys so we dont overwrite them
-                @($collectorAttribute.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($collectorAttribute[$_])) { $collectorAttribute.Remove($_) } }
+                @($collectorAttribute.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($collectorAttribute[$_])) { $collectorAttribute.Remove($_) } }
             }
 
             Try {
@@ -67,7 +67,7 @@ Function Set-LMTopologysource {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMTopologysource.ps1
+++ b/Public/Set-LMTopologysource.ps1
@@ -16,7 +16,7 @@ Function Set-LMTopologysource {
 
         [String]$TechNotes,
 
-        [ValidateSet("1800","3600","7200","21600")]
+        [ValidateSet("1800", "3600", "7200", "21600")]
         [Nullable[Int]]$PollingIntervalInSeconds,
 
         [String]$Group,
@@ -45,7 +45,7 @@ Function Set-LMTopologysource {
             $ResourcePath = "/setting/topologysources/$Id"
 
             $collectorAttribute = $null
-            If($ScriptType -or $Script){
+            If ($ScriptType -or $Script) {
                 $collectorAttribute = @{
                     groovyScript = $Script
                     scriptType   = $ScriptType
@@ -57,13 +57,13 @@ Function Set-LMTopologysource {
 
             Try {
                 $Data = @{
-                    name                      = $NewName
-                    description               = $Description
-                    appliesTo                 = $appliesTo
-                    technology                = $TechNotes
-                    group                     = $Group
-                    collectInterval           = $PollingIntervalInSeconds
-                    collectorAttribute        = $collectorAttribute
+                    name               = $NewName
+                    description        = $Description
+                    appliesTo          = $appliesTo
+                    technology         = $TechNotes
+                    group              = $Group
+                    collectInterval    = $PollingIntervalInSeconds
+                    collectorAttribute = $collectorAttribute
                 }
 
                 #Remove empty keys so we dont overwrite them

--- a/Public/Set-LMUnmonitoredDevice.ps1
+++ b/Public/Set-LMUnmonitoredDevice.ps1
@@ -24,9 +24,9 @@ Function Set-LMUnmonitoredDevice {
             Try {
                 $Data = @{
                     collectorId      = $CollectorId
-                    description               = $Description
-                    deviceGroupId             = $DeviceGroupId
-                    missingDeviceIds          = $Ids
+                    description      = $Description
+                    deviceGroupId    = $DeviceGroupId
+                    missingDeviceIds = $Ids
                 }
 
                 $Data = ($Data | ConvertTo-Json)

--- a/Public/Set-LMUser.ps1
+++ b/Public/Set-LMUser.ps1
@@ -114,7 +114,7 @@ Function Set-LMUser {
                         }
                         break
                     }
-                    ElseIf ($ViewPermission.ContainsKey($View)) {
+                    Elseif ($ViewPermission.ContainsKey($View)) {
                         $ViewPermission[$View] = $true
                     }
                 }
@@ -146,7 +146,7 @@ Function Set-LMUser {
 
                 }
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
 
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMWebsite.ps1
+++ b/Public/Set-LMWebsite.ps1
@@ -1,6 +1,6 @@
 Function Set-LMWebsite {
 
-    [CmdletBinding(DefaultParameterSetName="Website")]
+    [CmdletBinding(DefaultParameterSetName = "Website")]
     Param (
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [String]$Id,
@@ -19,38 +19,38 @@ Function Set-LMWebsite {
 
         [Nullable[boolean]]$UseDefaultLocationSetting,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[boolean]]$TriggerSSLStatusAlert,
         
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[boolean]]$TriggerSSLExpirationAlert,
 
         [String]$GroupId,
 
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [String]$PingAddress,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [String]$WebsiteDomain,
 
         [ValidateSet("http", "https")]
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [String]$HttpType,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [String[]]$SSLAlertThresholds,
         
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [ValidateSet(5, 10, 15, 20, 30, 60)]
         [Nullable[Int]]$PingCount,
 
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [Nullable[Int]]$PingTimeout,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [Nullable[Int]]$PageLoadAlertTimeInMS,
 
-        [Parameter(ParameterSetName="Ping")]
+        [Parameter(ParameterSetName = "Ping")]
         [ValidateSet(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)]
         [Nullable[Int]]$PingPercentNotReceived,
 
@@ -71,12 +71,12 @@ Function Set-LMWebsite {
         [ValidateSet(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
         [Nullable[Int]]$PollingInterval,
 
-        [Parameter(ParameterSetName="Website")]
+        [Parameter(ParameterSetName = "Website")]
         [String[]]$WebsiteSteps
     )
 
-    Begin{}
-    Process{
+    Begin {}
+    Process {
         #Check if we are logged in and have valid api creds
         If ($Script:LMAuth.Valid) {
 
@@ -161,5 +161,5 @@ Function Set-LMWebsite {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
     }
-    End{}
+    End {}
 }

--- a/Public/Set-LMWebsite.ps1
+++ b/Public/Set-LMWebsite.ps1
@@ -136,7 +136,7 @@ Function Set-LMWebsite {
 
             
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Set-LMWebsiteGroup.ps1
+++ b/Public/Set-LMWebsiteGroup.ps1
@@ -82,7 +82,7 @@ Function Set-LMWebsiteGroup {
                 }
 
                 #Remove empty keys so we dont overwrite them
-                @($Data.keys) | ForEach-Object { if ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
+                @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and ($_ -notin @($MyInvocation.BoundParameters.Keys))) { $Data.Remove($_) } }
             
                 $Data = ($Data | ConvertTo-Json)
 

--- a/README.md
+++ b/README.md
@@ -410,7 +410,6 @@ This change aims to enhance visibility within the community and to foster a more
 We appreciate your continued support and enthusiasm for the Logic.Monitor PowerShell module. Your contributions and feedback are vital to the success of this project, and we look forward to seeing how the module evolves with your participation.
 
 ## 6.1
-## 6.1
 ### New Cmdlets:
  - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
  - **New-LMAccessGroup**: This cmdlet creates a new LogicMonitor access group. 

--- a/README.md
+++ b/README.md
@@ -409,18 +409,26 @@ This change aims to enhance visibility within the community and to foster a more
 
 We appreciate your continued support and enthusiasm for the Logic.Monitor PowerShell module. Your contributions and feedback are vital to the success of this project, and we look forward to seeing how the module evolves with your participation.
 
-## 6.0
+## 6.1
 ### New Cmdlets:
- - **Get-LMDeviceInstanceData**: This cmdlet retrieves data for LogicMonitor device instances based on the specified parameters. The cmdlet can only retrieve data within the last 24 hours. You can use `Get-LMDeviceInstanceList` to quickly get a list of instances for a particular device.
- - **New-LMAlertEscalation**: This cmdlet invokes an escalation for a LogicMonitor alert. It takes a *-Ids* parameter which is an array of alert ids to escalate.
  - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
+ - **New-LMAccessGroup**: This cmdlet creates a new LogicMonitor access group. 
+ - **Set-LMAccessGroup**: This cmdlet updates an existing LogicMonitor access group. 
+ - **Remove-LMAccessGroup**: This cmdlet removes a new LogicMonitor access group. 
+ - **Get-LMDeviceDatasourceInstanceAlertRecipients**: Retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
+ - **Remove-LMDeviceDatasourceInstanceGroup**: Removes a LogicMonitor device datasource instance group.
+ - **Set-LMDeviceDatasourceInstance**: Updates a LogicMonitor device datasource instance.
  
  **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.
 
 
 ### Updated Cmdlets:
- - **Set-LMDeviceDatasourceInstanceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
- - **Set-LMDeviceGroupDatasourceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
+ - **Get-LMDeviceDatasourceList**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
+ - **Get-LMDeviceDatasourceInstance**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
+ - **Get-LMDeviceDatasourceInstanceAlertSetting**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets. Also fixed bug causing an issue when trying to retrieve instances with special characters in the name.
+ - **Get-LMDeviceDatasourceInstanceGroup**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
+ - **Remove-LMDeviceDatasourceInstance**: Fixed bug that would prevent a datasource instance from being delete due to missing instance id.
+
 
 [Previous Release Notes](RELEASENOTES.md)
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,17 @@
 # Previous module release notes
+## 6.0
+### New Cmdlets:
+ - **Get-LMDeviceInstanceData**: This cmdlet retrieves data for LogicMonitor device instances based on the specified parameters. The cmdlet can only retrieve data within the last 24 hours. You can use `Get-LMDeviceInstanceList` to quickly get a list of instances for a particular device.
+ - **New-LMAlertEscalation**: This cmdlet invokes an escalation for a LogicMonitor alert. It takes a *-Ids* parameter which is an array of alert ids to escalate.
+ - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
+ 
+ **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.
+
+
+### Updated Cmdlets:
+ - **Set-LMDeviceDatasourceInstanceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
+ - **Set-LMDeviceGroupDatasourceAlertSetting**: AlertForNoData, AlertClearTransitionInterval and AlertTransitionInterval parameters are now mandatory as a result of endpoint changes for LM APIv3. These values can now be set at instance and group level overrides and as a result must be specified when modifying alert thresholds.
+
 ## 5.1.3
 ### Updated Cmdlets:
 - **New-LMRole**:

--- a/Tests/LMDevice.Tests.ps1
+++ b/Tests/LMDevice.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Device Testing New/Get/Set/Remove' {
 
     Describe 'Set-LMDevice' {
         It 'When given a set of parameters, returns an updated resource with matching values' {
-            { $Device = Set-LMDevice -Id $Script:NewDevice.Id -Description "Updated" -Properties @{"test"="123";"test2"="456"}  -ErrorAction Stop
+            { $Device = Set-LMDevice -Id $Script:NewDevice.Id -Description "Updated" -Properties @{"test" = "123"; "test2" = "456" } -ErrorAction Stop
                 $Device.Description | Should -Be "Updated"
                 $Device.CustomProperties.name.IndexOf("test") | Should -Not -BeExactly -1
                 $Device.CustomProperties.name.IndexOf("test2") | Should -Not -BeExactly -1
@@ -74,7 +74,7 @@ Describe 'Device Testing New/Get/Set/Remove' {
 
     Describe 'Remove-LMDevice' {
         It 'When given an id, remove the device from logic monitor' {
-            { Remove-LMDevice -Id $Script:NewDevice.Id -HardDelete $true -Confirm:$false  -ErrorAction Stop} | Should -Not -Throw
+            { Remove-LMDevice -Id $Script:NewDevice.Id -HardDelete $true -Confirm:$false -ErrorAction Stop } | Should -Not -Throw
         }
     }
     

--- a/Tests/LMDeviceGroup.Tests.ps1
+++ b/Tests/LMDeviceGroup.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'DeviceGroup Testing New/Get/Set/Remove' {
     
     Describe 'New-LMDeviceGroup' {
         It 'When given mandatory parameters, returns a created group with matching values' {
-            $Script:NewDeviceGroup = New-LMDeviceGroup -Name "DeviceGroup.Build.Test" -Description "Testing123" -ParentGroupId 1 -Properties @{"testing"="123"} -DisableAlerting $true -AppliesTo "false()"
+            $Script:NewDeviceGroup = New-LMDeviceGroup -Name "DeviceGroup.Build.Test" -Description "Testing123" -ParentGroupId 1 -Properties @{"testing" = "123" } -DisableAlerting $true -AppliesTo "false()"
             $Script:NewDeviceGroup | Should -Not -BeNullOrEmpty
             $Script:NewDeviceGroup.Description | Should -Be "Testing123"
             $Script:NewDeviceGroup.DisableAlerting | Should -Be $true
@@ -36,7 +36,7 @@ Describe 'DeviceGroup Testing New/Get/Set/Remove' {
 
     Describe 'Set-LMDeviceGroup' {
         It 'When given a set of parameters, returns an updated group with matching values' {
-            { $DeviceGroup = Set-LMDeviceGroup -Id $Script:NewDeviceGroup.Id -Description "Updated" -Properties @{"test"="123";"test2"="456"} -ErrorAction Stop
+            { $DeviceGroup = Set-LMDeviceGroup -Id $Script:NewDeviceGroup.Id -Description "Updated" -Properties @{"test" = "123"; "test2" = "456" } -ErrorAction Stop
                 $DeviceGroup.Description | Should -Be "Updated"
                 $DeviceGroup.CustomProperties.name.IndexOf("test") | Should -Not -BeExactly -1
                 $DeviceGroup.CustomProperties.name.IndexOf("test2") | Should -Not -BeExactly -1

--- a/Tests/LMOpsNotes.Tests.ps1
+++ b/Tests/LMOpsNotes.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'OpsNotes Testing New/Get/Set/Remove' {
         }
         It 'When given an id should return that opsnote' {
             $Retry = 0
-            While(!$OpsNote -or $Retry -eq 5){
+            While (!$OpsNote -or $Retry -eq 5) {
                 $OpsNote = Get-LMOpsNote -Id $Script:NewOpsNote.Id -ErrorAction SilentlyContinue
                 $Retry++
             }
@@ -31,7 +31,7 @@ Describe 'OpsNotes Testing New/Get/Set/Remove' {
         }
         It 'When given a name should return specified opsnote matching that tag value' {
             $Retry = 0
-            While(!$OpsNote -or $Retry -eq 5){
+            While (!$OpsNote -or $Retry -eq 5) {
                 $OpsNote = Get-LMOpsNote -Tag $Script:NewOpsNote.Tags.name -ErrorAction SilentlyContinue
                 $Retry++
             }
@@ -39,8 +39,8 @@ Describe 'OpsNotes Testing New/Get/Set/Remove' {
         }
         It 'When given a wildcard name should return all opsnotes matching that wildcard value' {
             $Retry = 0
-            While(!$OpsNote -or $Retry -eq 5){
-                $OpsNote = Get-LMOpsNote -Tag "$(($Script:NewOpsNote.Tags.name.Split(".")[0]))*"  -ErrorAction SilentlyContinue
+            While (!$OpsNote -or $Retry -eq 5) {
+                $OpsNote = Get-LMOpsNote -Tag "$(($Script:NewOpsNote.Tags.name.Split(".")[0]))*" -ErrorAction SilentlyContinue
                 $Retry++
             }
             ($OpsNote | Measure-Object).Count | Should -BeGreaterThan 0

--- a/Tests/LMUser-Role.Tests.ps1
+++ b/Tests/LMUser-Role.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'User & Role Testing New/Get/Set/Remove' {
 
     Describe 'Remove-LMRole' {
         It 'When given an id, remove the role from logic monitor' {
-            { Remove-LMRole -Id $Script:NewRole.Id -ErrorAction Stop -Confirm:$false  } | Should -Not -Throw
+            { Remove-LMRole -Id $Script:NewRole.Id -ErrorAction Stop -Confirm:$false } | Should -Not -Throw
         }
     }
     

--- a/Tests/LMWebsite.Tests.ps1
+++ b/Tests/LMWebsite.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'Website Testing New/Get/Set/Remove' {
     
     Describe 'New-LMWebsite' {
         It 'When given mandatory parameters, returns a created website with matching values' {
-            $Script:NewWebsite = New-LMWebsite -Name "Website.Build.Test"  -Webcheck -WebsiteDomain "example.com" -Description "BuildTest" -Properties @{"testprop"="BuildTest"}
+            $Script:NewWebsite = New-LMWebsite -Name "Website.Build.Test" -Webcheck -WebsiteDomain "example.com" -Description "BuildTest" -Properties @{"testprop" = "BuildTest" }
             $Script:NewWebsite | Should -Not -BeNullOrEmpty
             $Script:NewWebsite.Description | Should -BeExactly "BuildTest"
             $Script:NewWebsite.properties.name.IndexOf("testprop") | Should -Not -BeExactly -1
@@ -15,7 +15,7 @@ Describe 'Website Testing New/Get/Set/Remove' {
 
     Describe 'Get-LMWebsiteProperty' {
         It 'When given mandatory parameters, returns a specified property' {
-            $WebsiteProp = Get-LMWebsiteProperty -Id $Script:NewWebsite.Id | Where-Object {$_.name -eq "testprop"}
+            $WebsiteProp = Get-LMWebsiteProperty -Id $Script:NewWebsite.Id | Where-Object { $_.name -eq "testprop" }
             $WebsiteProp | Should -Not -BeNullOrEmpty
         }
     }
@@ -45,7 +45,7 @@ Describe 'Website Testing New/Get/Set/Remove' {
 
     Describe 'Set-LMWebsite' {
         It 'When given a set of parameters, returns an updated website with matching values' {
-            { $Device = Set-LMWebsite -Id $Script:NewWebsite.Id -Description "Updated" -Properties @{"test"="123";"test2"="456"} -ErrorAction Stop
+            { $Device = Set-LMWebsite -Id $Script:NewWebsite.Id -Description "Updated" -Properties @{"test" = "123"; "test2" = "456" } -ErrorAction Stop
                 $Device.Description | Should -Be "Updated"
                 $Device.Properties.name.IndexOf("test") | Should -Not -BeExactly -1
                 $Device.Properties.name.IndexOf("test2") | Should -Not -BeExactly -1

--- a/Tests/LMWebsiteGroup.Tests.ps1
+++ b/Tests/LMWebsiteGroup.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'WebsiteGroup Testing New/Get/Set/Remove' {
     
     Describe 'New-LMWebsiteGroup' {
         It 'When given mandatory parameters, returns a created group with matching values' {
-            $Script:NewWebsiteGroup = New-LMWebsiteGroup -Name "WebsiteGroup.Build.Test" -Description "Testing123" -ParentGroupId 1 -Properties @{"testing"="123"} -DisableAlerting $true
+            $Script:NewWebsiteGroup = New-LMWebsiteGroup -Name "WebsiteGroup.Build.Test" -Description "Testing123" -ParentGroupId 1 -Properties @{"testing" = "123" } -DisableAlerting $true
             $Script:NewWebsiteGroup | Should -Not -BeNullOrEmpty
             $Script:NewWebsiteGroup.Description | Should -Be "Testing123"
             $Script:NewWebsiteGroup.DisableAlerting | Should -Be $true
@@ -35,7 +35,7 @@ Describe 'WebsiteGroup Testing New/Get/Set/Remove' {
 
     Describe 'Set-LMWebsiteGroup' {
         It 'When given a set of parameters, returns an updated group with matching values' {
-            { $WebsiteGroup = Set-LMWebsiteGroup -Id $Script:NewWebsiteGroup.Id -Description "Updated" -Properties @{"test"="123";"test2"="456"} -ErrorAction Stop
+            { $WebsiteGroup = Set-LMWebsiteGroup -Id $Script:NewWebsiteGroup.Id -Description "Updated" -Properties @{"test" = "123"; "test2" = "456" } -ErrorAction Stop
                 $WebsiteGroup.Description | Should -Be "Updated"
                 $WebsiteGroup.Properties.name.IndexOf("test") | Should -Not -BeExactly -1
                 $WebsiteGroup.Properties.name.IndexOf("test2") | Should -Not -BeExactly -1

--- a/en-US/Logic.Monitor-help.xml
+++ b/en-US/Logic.Monitor-help.xml
@@ -2447,6 +2447,234 @@ Creates a copy of the device specified by the $deviceObject variable with the na
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-LMAccessGroup</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMAccessGroup</command:noun>
+      <maml:description>
+        <maml:para>Retrieves LogicMonitor access groups based on specified parameters.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMAccessGroup function retrieves LogicMonitor access groups based on the specified parameters. It supports retrieving access groups by ID, name, or using a filter. The function uses the LogicMonitor REST API to make the requests.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Specifies the ID of the access group to retrieve. This parameter is mutually exclusive with the Name and Filter parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the name of the access group to retrieve. This parameter is mutually exclusive with the Id and Filter parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>Specifies a filter object to retrieve access groups based on custom filter criteria. This parameter is mutually exclusive with the Id and Name parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Specifies the ID of the access group to retrieve. This parameter is mutually exclusive with the Name and Filter parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Specifies the name of the access group to retrieve. This parameter is mutually exclusive with the Id and Filter parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Filter</maml:name>
+        <maml:description>
+          <maml:para>Specifies a filter object to retrieve access groups based on custom filter criteria. This parameter is mutually exclusive with the Id and Name parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Specifies the number of access groups to retrieve per request. The default value is 1000.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1000</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires a valid LogicMonitor API authentication. Use Connect-LMAccount to authenticate before running this function.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMAccessGroup -Id 123
+Retrieves the access group with the specified ID.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-LMAccessGroup -Name "MyAccessGroup"
+Retrieves the access group with the specified name.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Get-LMAccessGroup -Filter @{ Property = "Value" }
+Retrieves access groups based on the specified filter criteria.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-LMAccountStatus</command:name>
       <command:verb>Get</command:verb>
       <command:noun>LMAccountStatus</command:noun>
@@ -4073,6 +4301,73 @@ Retrieves audit logs that contain the search string "login" and occurred within 
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-LMAWSAccountId</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMAWSAccountId</command:noun>
+      <maml:description>
+        <maml:para>Retrieves the AWS Account ID associated with the LogicMonitor account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMAWSAccountId function is used to retrieve the AWS Account ID associated with the LogicMonitor account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, and then sends a GET request to the LogicMonitor API to retrieve the AWS Account ID. The function returns the response containing the AWS Account ID.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMAWSAccountId</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMAWSAccountId
+Retrieves the AWS Account ID associated with the LogicMonitor account.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://www.logicmonitor.com/support/rest-api-developers-guide/</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-LMCachedAccount</command:name>
       <command:verb>Get</command:verb>
       <command:noun>LMCachedAccount</command:noun>
@@ -5556,6 +5851,282 @@ Retrieves the configuration source with the name "MyConfigSource".</dev:code>
         <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
         <dev:code>Get-LMConfigSource -Filter @{ Property = "Value" }
 Retrieves configuration sources based on the specified filter criteria.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-LMConfigsourceUpdateHistory</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMConfigsourceUpdateHistory</command:noun>
+      <maml:description>
+        <maml:para>Retrieves the update history for a LogicMonitor configuration source.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMConfigsourceUpdateHistory function retrieves the update history for a LogicMonitor configuration source. It can be used to get information about the updates made to a configuration source, such as the update reasons and the modules that were updated.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMConfigsourceUpdateHistory</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>The ID of the configuration source. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>0</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMConfigsourceUpdateHistory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>The name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'Name' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMConfigsourceUpdateHistory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DisplayName</maml:name>
+          <maml:description>
+            <maml:para>The display name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'DisplayName' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1000</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>The ID of the configuration source. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>0</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>The name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'Name' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DisplayName</maml:name>
+        <maml:description>
+          <maml:para>The display name of the configuration source. This parameter is used to look up the ID of the configuration source. This parameter is used when using the 'DisplayName' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Filter</maml:name>
+        <maml:description>
+          <maml:para>A filter object that specifies additional filtering criteria for the update history. This parameter is optional.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>The number of results to retrieve per request. The default value is 1000. This parameter is optional.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1000</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMConfigsourceUpdateHistory -Id 1234
+Retrieves the update history for the configuration source with the ID 1234.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Get-LMConfigsourceUpdateHistory -Name "MyConfigSource"
+Retrieves the update history for the configuration source with the name "MyConfigSource".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 3 --------------------------</maml:title>
+        <dev:code>Get-LMConfigsourceUpdateHistory -DisplayName "My Config Source"
+Retrieves the update history for the configuration source with the display name "My Config Source".</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -8471,6 +9042,30 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Id Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Filter Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>BatchSize</maml:name>
           <maml:description>
@@ -8483,6 +9078,72 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Filter Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill BatchSize Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>DisplayName</maml:name>
           <maml:description>
@@ -8507,21 +9168,6 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
-          <maml:name>ProgressAction</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
-          <dev:type>
-            <maml:name>ActionPreference</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>BatchSize</maml:name>
           <maml:description>
@@ -8530,81 +9176,6 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Filter</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill Filter Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
-          <dev:type>
-            <maml:name>Object</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Id</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill Id Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
-          <maml:name>ProgressAction</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
-          <dev:type>
-            <maml:name>ActionPreference</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Get-LMDatasourceUpdateHistory</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>BatchSize</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill BatchSize Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
-          <dev:type>
-            <maml:name>Int32</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Filter</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill Filter Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
-          <dev:type>
-            <maml:name>Object</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>Name</maml:name>
-          <maml:description>
-            <maml:para>{{ Fill Name Description }}</maml:para>
-          </maml:description>
-          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-          <dev:type>
-            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -8624,14 +9195,26 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>BatchSize</maml:name>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
         <maml:description>
-          <maml:para>{{ Fill BatchSize Description }}</maml:para>
+          <maml:para>{{ Fill Id Description }}</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
           <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Name Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -8660,26 +9243,14 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
-      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>Id</maml:name>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>BatchSize</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Id Description }}</maml:para>
+          <maml:para>{{ Fill BatchSize Description }}</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
         <dev:type>
           <maml:name>Int32</maml:name>
-          <maml:uri />
-        </dev:type>
-        <dev:defaultValue>None</dev:defaultValue>
-      </command:parameter>
-      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-        <maml:name>Name</maml:name>
-        <maml:description>
-          <maml:para>{{ Fill Name Description }}</maml:para>
-        </maml:description>
-        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
-        <dev:type>
-          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -11150,6 +11721,394 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
         <dev:type>
           <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-LMDeviceDatasourceInstanceAlertRecipients</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMDeviceDatasourceInstanceAlertRecipients</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMDeviceDatasourceInstanceAlertRecipients</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DataPointName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DataPointName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DatasourceId</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DatasourceId Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InstanceName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InstanceName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMDeviceDatasourceInstanceAlertRecipients</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DataPointName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DataPointName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DatasourceId</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DatasourceId Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Id Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InstanceName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InstanceName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMDeviceDatasourceInstanceAlertRecipients</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DataPointName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DataPointName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DatasourceName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DatasourceName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InstanceName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InstanceName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Get-LMDeviceDatasourceInstanceAlertRecipients</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DataPointName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DataPointName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DatasourceName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DatasourceName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Id Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InstanceName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InstanceName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DataPointName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DataPointName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DatasourceId</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DatasourceId Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DatasourceName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DatasourceName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Id Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>InstanceName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InstanceName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Name Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -14738,6 +15697,188 @@ Retrieves the dashboards that match the specified custom filter.</dev:code>
         <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
         <dev:remarks>
           <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-LMDeviceInstanceData</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>LMDeviceInstanceData</command:noun>
+      <maml:description>
+        <maml:para>Retrieves data for LogicMonitor device instances.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Get-LMDeviceInstanceData function retrieves data for LogicMonitor device instances based on the specified parameters.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-LMDeviceInstanceData</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>StartDate</maml:name>
+          <maml:description>
+            <maml:para>The start date for the data retrieval. If not specified, the function uses the default value of 24 hours ago which is the max timeframe for this endpoint.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>EndDate</maml:name>
+          <maml:description>
+            <maml:para>The end date for the data retrieval. If not specified, the function uses the current date and time.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTime</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="Id">
+          <maml:name>Ids</maml:name>
+          <maml:description>
+            <maml:para>The array of device instance IDs for which to retrieve data. This parameter is mandatory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>AggregationType</maml:name>
+          <maml:description>
+            <maml:para>The type of aggregation to apply to the retrieved data. Valid values are "first", "last", "min", "max", "sum", "average", and "none". The default value is "none".</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+          <maml:name>Period</maml:name>
+          <maml:description>
+            <maml:para>The period for the data retrieval. The default value is 1.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>StartDate</maml:name>
+        <maml:description>
+          <maml:para>The start date for the data retrieval. If not specified, the function uses the default value of 24 hours ago which is the max timeframe for this endpoint.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTime</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>EndDate</maml:name>
+        <maml:description>
+          <maml:para>The end date for the data retrieval. If not specified, the function uses the current date and time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTime</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTime</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="Id">
+        <maml:name>Ids</maml:name>
+        <maml:description>
+          <maml:para>The array of device instance IDs for which to retrieve data. This parameter is mandatory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>AggregationType</maml:name>
+        <maml:description>
+          <maml:para>The type of aggregation to apply to the retrieved data. Valid values are "first", "last", "min", "max", "sum", "average", and "none". The default value is "none".</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+        <maml:name>Period</maml:name>
+        <maml:description>
+          <maml:para>The period for the data retrieval. The default value is 1.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires a valid LogicMonitor API authentication. Make sure to log in using Connect-LMAccount before running this command.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Get-LMDeviceInstanceData -StartDate (Get-Date).AddHours(-7) -EndDate (Get-Date) -Ids "12345", "67890" -AggregationType "average" -Period 1
+Retrieves data for the device instances with IDs "12345" and "67890" for the past 7 hours, using an average aggregation and a period of 1 day.</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -24938,6 +26079,573 @@ Invokes an active discovery task for all devices in the device group with the na
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Invoke-LMAWSAccountTest</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMAWSAccountTest</command:noun>
+      <maml:description>
+        <maml:para>Invokes a test for an AWS account in LogicMonitor.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMAWSAccountTest function is used to invoke a test for an AWS account in LogicMonitor. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test. The function returns the response from the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMAWSAccountTest</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ExternalId</maml:name>
+          <maml:description>
+            <maml:para>The external ID of the AWS account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>AccountId</maml:name>
+          <maml:description>
+            <maml:para>The account ID of the AWS account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>AssumedRoleARN</maml:name>
+          <maml:description>
+            <maml:para>The assumed role ARN of the AWS account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>CheckedServices</maml:name>
+          <maml:description>
+            <maml:para>The list of services to be checked during the test. Default value is a comma-separated string of service names supported by LogicMonitor.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>The device group ID to which the AWS account belongs. Default value is -1 for no group.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>-1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ExternalId</maml:name>
+        <maml:description>
+          <maml:para>The external ID of the AWS account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>AccountId</maml:name>
+        <maml:description>
+          <maml:para>The account ID of the AWS account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>AssumedRoleARN</maml:name>
+        <maml:description>
+          <maml:para>The assumed role ARN of the AWS account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>CheckedServices</maml:name>
+        <maml:description>
+          <maml:para>The list of services to be checked during the test. Default value is a comma-separated string of service names supported by LogicMonitor.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>DYNAMODB,EBS,EC2,AUTOSCALING,BACKUP,BACKUPPROTECTEDRESOURCE,TRANSFER,ELASTICACHE,ELB,RDS,REDSHIFT,S3,SNS,SQS,EMR,KINESIS,ROUTE53,ROUTE53HOSTEDZONE,CLOUDSEARCH,LAMBDA,ECR,ECS,ELASTICSEARCH,EFS,SWFWORKFLOW,SWFACTIVITY,APPLICATIONELB,CLOUDFRONT,APIGATEWAY,APIGATEWAYV2,SES,VPN,FIREHOSE,KINESISVIDEO,WORKSPACE,NETWORKELB,NATGATEWAY,DIRECTCONNECT,DIRECTCONNECT_VIRTUALINTERFACE,WORKSPACEDIRECTORY,ELASTICBEANSTALK,DMSREPLICATION,MSKCLUSTER,MSKBROKER,FSX,TRANSITGATEWAY,GLUE,APPSTREAM,MQ,ATHENA,DBCLUSTER,DOCDB,STEPFUNCTIONS,OPSWORKS,CODEBUILD,SAGEMAKER,ROUTE53RESOLVER,DMSREPLICATIONTASKS,EVENTBRIDGE,MEDIACONNECT,MEDIAPACKAGELIVE,MEDIASTORE,MEDIAPACKAGEVOD,MEDIATAILOR,MEDIACONVERT,ELASTICTRANSCODER,COGNITO,TRANSITGATEWAYATTACHMENT,QUICKSIGHT_DASHBOARDS,QUICKSIGHT_DATASETS,PRIVATELINK_ENDPOINTS,PRIVATELINK_SERVICES,GLOBAL_NETWORKS</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>The device group ID to which the AWS account belongs. Default value is -1 for no group.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>-1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires the user to be logged in before running any commands. Use the Connect-LMAccount function to log in before invoking this function.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMAWSAccountTest -ExternalId "123456" -AccountId "987654" -AccessId "AKI123" -AccessKey "abc123" -AssumedRoleARN "arn:aws:iam::123456789012:role/MyRole" -CheckedServices "EC2,S3,RDS" -GroupId 123</dev:code>
+        <dev:remarks>
+          <maml:para>This example invokes a test for an AWS account with the specified parameters.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Invoke-LMAzureAccountTest</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMAzureAccountTest</command:noun>
+      <maml:description>
+        <maml:para>Invokes a test on an Azure account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMAzureAccountTest function is used to invoke a test on an Azure account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, and then sends a POST request to the specified endpoint. The function returns the response from the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMAzureAccountTest</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ClientId</maml:name>
+          <maml:description>
+            <maml:para>The client ID of the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>SecretKey</maml:name>
+          <maml:description>
+            <maml:para>The secret key of the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>CheckedServices</maml:name>
+          <maml:description>
+            <maml:para>The list of services to be checked. Default value is a list of commonly used Azure services.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>SubscriptionIds</maml:name>
+          <maml:description>
+            <maml:para>The subscription IDs associated with the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>The group ID. Default value is -1.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>-1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="none">
+          <maml:name>TenantId</maml:name>
+          <maml:description>
+            <maml:para>The tenant ID of the Azure account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
+          <maml:name>IsChinaAccount</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ClientId</maml:name>
+        <maml:description>
+          <maml:para>The client ID of the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>SecretKey</maml:name>
+        <maml:description>
+          <maml:para>The secret key of the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>CheckedServices</maml:name>
+        <maml:description>
+          <maml:para>The list of services to be checked. Default value is a list of commonly used Azure services.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>VIRTUALMACHINE,SQLDATABASE,APPSERVICE,EVENTHUB,REDISCACHE,REDISCACHEENTERPRISE,VIRTUALMACHINESCALESET,VIRTUALMACHINESCALESETVM,APPLICATIONGATEWAY,IOTHUB,FUNCTION,SERVICEBUS,MARIADB,MYSQL,MYSQLFLEXIBLE,POSTGRESQL,POSTGRESQLFLEXIBLE,POSTGRESQLCITUS,ANALYSISSERVICE,TABLESTORAGE,BLOBSTORAGE,FILESTORAGE,QUEUESTORAGE,STORAGEACCOUNT,APIMANAGEMENT,COSMOSDB,APPSERVICEPLAN,VIRTUALNETWORKGATEWAY,AUTOMATIONACCOUNT,EXPRESSROUTECIRCUIT,DATALAKEANALYTICS,DATALAKESTORE,APPLICATIONINSIGHTS,FIREWALL,SQLELASTICPOOL,SQLMANAGEDINSTANCE,HDINSIGHT,RECOVERYSERVICES,BACKUPPROTECTEDITEMS,RECOVERYPROTECTEDITEMS,NETWORKINTERFACE,BATCHACCOUNT,LOGICAPPS,DATAFACTORY,PUBLICIP,STREAMANALYTICS,EVENTGRID,LOADBALANCERS,SERVICEFABRICMESH,COGNITIVESEARCH,COGNITIVESERVICES,MLWORKSPACES,FRONTDOORS,KEYVAULT,RELAYNAMESPACES,NOTIFICATIONHUBS,APPSERVICEENVIRONMENT,TRAFFICMANAGER,SIGNALR,VIRTUALDESKTOP,SYNAPSEWORKSPACES,NETAPPPOOLS,DATABRICKS,LOGANALYTICSWORKSPACES,VIRTUALHUBS,VPNGATEWAYS,CDNPROFILE,POWERBIEMBEDDED,CONTAINERREGISTRY,NATGATEWAYS,BOTSERVICES,VIRTUALNETWORKS</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>SubscriptionIds</maml:name>
+        <maml:description>
+          <maml:para>The subscription IDs associated with the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="5" aliases="none">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>The group ID. Default value is -1.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>-1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="6" aliases="none">
+        <maml:name>TenantId</maml:name>
+        <maml:description>
+          <maml:para>The tenant ID of the Azure account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="7" aliases="none">
+        <maml:name>IsChinaAccount</maml:name>
+        <maml:description>
+          <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMAzureAccountTest -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SubscriptionIds "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"</dev:code>
+        <dev:remarks>
+          <maml:para>This example invokes a test on an Azure account using the specified client ID, secret key, and subscription IDs.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Invoke-LMAzureSubscriptionDiscovery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMAzureSubscriptionDiscovery</command:noun>
+      <maml:description>
+        <maml:para>Invokes the Azure subscription discovery process to return subscriptions for a specified client Id.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMAzureSubscriptionDiscovery function is used to discover Azure subscriptions by making API requests to the LogicMonitor platform.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMAzureSubscriptionDiscovery</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ClientId</maml:name>
+          <maml:description>
+            <maml:para>The client ID of the Azure Active Directory application.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>SecretKey</maml:name>
+          <maml:description>
+            <maml:para>The secret key of the Azure Active Directory application.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>TenantId</maml:name>
+          <maml:description>
+            <maml:para>The tenant ID of the Azure Active Directory application.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>IsChinaAccount</maml:name>
+          <maml:description>
+            <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ClientId</maml:name>
+        <maml:description>
+          <maml:para>The client ID of the Azure Active Directory application.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>SecretKey</maml:name>
+        <maml:description>
+          <maml:para>The secret key of the Azure Active Directory application.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>TenantId</maml:name>
+        <maml:description>
+          <maml:para>The tenant ID of the Azure Active Directory application.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>IsChinaAccount</maml:name>
+        <maml:description>
+          <maml:para>Specifies whether the Azure account is a China account. Default value is $false.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMAzureSubscriptionDiscovery -ClientId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -SecretKey "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Invoke-LMCloudGroupNetScan</command:name>
       <command:verb>Invoke</command:verb>
       <command:noun>LMCloudGroupNetScan</command:noun>
@@ -26107,6 +27815,163 @@ Schedules a configuration collection task for the device with the ID 123, the da
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Invoke-LMGCPAccountTest</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>LMGCPAccountTest</command:noun>
+      <maml:description>
+        <maml:para>Invokes a test for a GCP (Google Cloud Platform) account.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Invoke-LMGCPAccountTest function is used to invoke a test for a GCP account. It checks if the user is logged in and has valid API credentials. If the user is logged in, it builds the necessary headers and URI, prepares the data, and sends a POST request to the LogicMonitor API to perform the test. The function returns the response from the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Invoke-LMGCPAccountTest</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>ServiceAccountKey</maml:name>
+          <maml:description>
+            <maml:para>The service account key for the GCP account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>The ID of the GCP project.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+          <maml:name>CheckedServices</maml:name>
+          <maml:description>
+            <maml:para>(Optional) A comma-separated list of GCP services to be checked. The default value is a list of all LM supported GCP services.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+          <maml:name>GroupId</maml:name>
+          <maml:description>
+            <maml:para>(Optional) The ID of the group to which the GCP account belongs. The default value is -1, indicating no group.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>-1</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>ServiceAccountKey</maml:name>
+        <maml:description>
+          <maml:para>The service account key for the GCP account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>The ID of the GCP project.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="3" aliases="none">
+        <maml:name>CheckedServices</maml:name>
+        <maml:description>
+          <maml:para>(Optional) A comma-separated list of GCP services to be checked. The default value is a list of all LM supported GCP services.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>CLOUDRUN,CLOUDDNS,REGIONALHTTPSLOADBALANCER,COMPUTEENGINEAUTOSCALER,COMPUTEENGINE,CLOUDIOT,CLOUDROUTER,CLOUDTASKS,VPNGATEWAY,CLOUDREDIS,CLOUDCOMPOSER,INTERCONNECTATTACHMENT,CLOUDFUNCTION,CLOUDBIGTABLE,CLOUDFILESTORE,CLOUDPUBSUB,CLOUDTRACE,CLOUDSTORAGE,CLOUDDATAPROC,CLOUDINTERCONNECT,CLOUDAIPLATFORM,CLOUDSQL,MANAGEDSERVICEFORMICROSOFTAD,CLOUDFIRESTORE,CLOUDDATAFLOW,CLOUDTPU,CLOUDDLP,APPENGINE,HTTPSLOADBALANCER,CLOUDSPANNER</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="none">
+        <maml:name>GroupId</maml:name>
+        <maml:description>
+          <maml:para>(Optional) The ID of the group to which the GCP account belongs. The default value is -1, indicating no group.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>-1</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires the user to be logged in before running any commands. Use the Connect-LMAccount function to log in before invoking this function.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Invoke-LMGCPAccountTest -ServiceAccountKey "service-account-key" -ProjectId "project-id"</dev:code>
+        <dev:remarks>
+          <maml:para>This example invokes a test for a GCP account using the specified service account key and project ID.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Invoke-LMNetScan</command:name>
       <command:verb>Invoke</command:verb>
       <command:noun>LMNetScan</command:noun>
@@ -26279,6 +28144,157 @@ Invokes a session logoff for the users "user1" and "user2" in Logic Monitor.</de
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>New-LMAccessGroup</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>LMAccessGroup</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-LMAccessGroup</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Description Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>Tenant</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Tenant Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>Description</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Description Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Name Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>Tenant</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Tenant Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>New-LMAlertAck</command:name>
       <command:verb>New</command:verb>
       <command:noun>LMAlertAck</command:noun>
@@ -26381,6 +28397,92 @@ Invokes a session logoff for the users "user1" and "user2" in Logic Monitor.</de
         <dev:code>New-LMAlertAck -Ids @("12345","67890") -Note "Acknowledging alerts"</dev:code>
         <dev:remarks>
           <maml:para>This example acknowledges the alerts with the IDs "12345" and "67890" and adds the note "Acknowledging alerts" to the acknowledgment.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>New-LMAlertEscalation</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>LMAlertEscalation</command:noun>
+      <maml:description>
+        <maml:para>Creates a new escalation for a LogicMonitor alert.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The New-LMAlertEscalation function creates a new escalation for a LogicMonitor alert. It checks if the user is logged in and has valid API credentials before making the API request to create the escalation.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-LMAlertEscalation</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>The ID of the alert for which the escalation needs to be created.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>The ID of the alert for which the escalation needs to be created.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>New-LMAlertEscalation -Id "DS12345"
+Creates a new escalation for the alert with ID "12345".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -38378,6 +40480,216 @@ Creates a new network scan with the specified collector ID, name, and subnet ran
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Remove-LMAccessGroup</command:name>
+      <command:verb>Remove</command:verb>
+      <command:noun>LMAccessGroup</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Remove-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Id Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Remove-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Id Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Name Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Int32</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Remove-LMAPIToken</command:name>
       <command:verb>Remove</command:verb>
       <command:noun>LMAPIToken</command:noun>
@@ -45162,6 +47474,256 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Set-LMAccessGroup</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>LMAccessGroup</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Description Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Id Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NewName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NewName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Tenant</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Tenant Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-LMAccessGroup</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Description</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Description Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NewName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NewName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Tenant</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Tenant Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Description</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Description Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Id Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Name Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NewName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NewName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Tenant</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Tenant Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Int32</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Set-LMAPIToken</command:name>
       <command:verb>Set</command:verb>
       <command:noun>LMAPIToken</command:noun>
@@ -48861,6 +51423,18 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
     <command:syntax>
       <command:syntaxItem>
         <maml:name>Set-LMDevice</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AutoBalancedCollectorGroupId</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AutoBalancedCollectorGroupId Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:description>
@@ -49095,6 +51669,18 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>Set-LMDevice</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AutoBalancedCollectorGroupId</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AutoBalancedCollectorGroupId Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
           <maml:name>Confirm</maml:name>
           <maml:description>
@@ -49329,6 +51915,18 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AutoBalancedCollectorGroupId</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AutoBalancedCollectorGroupId Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
         <maml:name>Confirm</maml:name>
         <maml:description>
@@ -59554,6 +62152,269 @@ Removes the LogicMonitor role with the Name "Admin".</dev:code>
         <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
         <dev:remarks>
           <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Set-LMUserdata</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>LMUserdata</command:noun>
+      <maml:description>
+        <maml:para>Sets userdata for a LogicMonitor user. Currently only setting the default dashboard is supported.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Set-LMUserdata function is used to set the user data for a LogicMonitor user. It allows you to specify the user by either their Id or Name, and the dashboard Id for which the user data should be set.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-LMUserdata</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>Id</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Id of the user. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DashboardId</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Set-LMUserdata</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Name of the user. This parameter is mandatory when using the 'Name' parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DashboardId</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+          <maml:name>ProgressAction</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+          <dev:type>
+            <maml:name>ActionPreference</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>Id</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Id of the user. This parameter is mandatory when using the 'Id' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Name of the user. This parameter is mandatory when using the 'Name' parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DashboardId</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Id of the dashboard for which the user data should be set. This parameter is mandatory.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="proga">
+        <maml:name>ProgressAction</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ProgressAction Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActionPreference</command:parameterValue>
+        <dev:type>
+          <maml:name>ActionPreference</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None.</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Returns the response from the LogicMonitor API.</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>This function requires a valid API authentication. Make sure you are logged in before running any commands using Connect-LMAccount.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>Set-LMUserdata -Id "12345" -DashboardId "67890"
+Sets the user data for the user with Id "12345" for the dashboard with Id "67890".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 2 --------------------------</maml:title>
+        <dev:code>Set-LMUserdata -Name "JohnDoe" -DashboardId "67890"
+Sets the user data for the user with Name "JohnDoe" for the dashboard with Id "67890".</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>


### PR DESCRIPTION
## 6.1
### New Cmdlets:
 - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
 - **New-LMAccessGroup**: This cmdlet creates a new LogicMonitor access group. 
 - **Set-LMAccessGroup**: This cmdlet updates an existing LogicMonitor access group. 
 - **Remove-LMAccessGroup**: This cmdlet removes a new LogicMonitor access group. 
 - **Get-LMDeviceDatasourceInstanceAlertRecipients**: Retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
 - **Remove-LMDeviceDatasourceInstanceGroup**: Removes a LogicMonitor device datasource instance group.
 - **Set-LMDeviceDatasourceInstance**: Updates a LogicMonitor device datasource instance.
 
 **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.


### Updated Cmdlets:
 - **Get-LMDeviceDatasourceList**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
 - **Get-LMDeviceDatasourceInstance**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
 - **Get-LMDeviceDatasourceInstanceAlertSetting**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets. Also fixed bug causing an issue when trying to retrieve instances with special characters in the name.
 - **Get-LMDeviceDatasourceInstanceGroup**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
 - **Remove-LMDeviceDatasourceInstance**: Fixed bug that would prevent a datasource instance from being delete due to missing instance id.