### PR TITLE
6.3 pre release

### DIFF
--- a/Logic.Monitor.Format.ps1xml
+++ b/Logic.Monitor.Format.ps1xml
@@ -1467,6 +1467,53 @@
             </TableRowEntries>
          </TableControl>
       </View>
+      <!-- New View LogicMonitor.Logsource-->
+      <View>
+         <Name>LogicMonitorLogsource</Name>
+         <ViewSelectedBy>
+            <TypeName>LogicMonitor.Logsource</TypeName>
+         </ViewSelectedBy>
+         <TableControl>
+            <TableHeaders>
+               <TableColumnHeader>
+                  <Label>id</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>name</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>logFields</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>resourceMapping</Label>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>description</Label>
+               </TableColumnHeader>
+            </TableHeaders>
+            <TableRowEntries>
+               <TableRowEntry>
+                  <TableColumnItems>
+                     <TableColumnItem>
+                        <PropertyName>id</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>name</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>logFields</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>resourceMapping</PropertyName>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>description</PropertyName>
+                     </TableColumnItem>
+                  </TableColumnItems>
+               </TableRowEntry>
+            </TableRowEntries>
+         </TableControl>
+      </View>
       <!-- New View LogicMonitor.Propertysource-->
       <View>
          <Name>LogicMonitorPropertysource</Name>

--- a/Public/Export-LMLogicModule.ps1
+++ b/Public/Export-LMLogicModule.ps1
@@ -47,7 +47,7 @@ Function Export-LMLogicModule {
         [String]$LogicModuleName,
 
         [Parameter(Mandatory)]
-        [ValidateSet("datasources", "propertyrules", "eventsources", "topologysources", "configsources")]
+        [ValidateSet("datasources", "propertyrules", "eventsources", "topologysources", "configsources","logsources")]
         [String]$Type,
 
         [String]$DownloadPath = (Get-Location).Path
@@ -91,6 +91,11 @@ Function Export-LMLogicModule {
                         $ExportPath = $DownloadPath + "\$($LogicModuleInfo.name).xml"
                         $QueryParams = "?format=xml&v=3"
                     }
+                    "logsources" {
+                        $LogicModuleInfo = Get-LMLogSource -Name $LogicModuleName
+                        $ExportPath = $DownloadPath + "\$($LogicModuleInfo.name).xml"
+                        $QueryParams = "?format=xml&v=3"
+                    }
                 }
                 #Verify our query only returned one result
                 If (Test-LookupResult -Result $LogicModuleInfo.Id -LookupString $LogicModuleName) {
@@ -123,6 +128,11 @@ Function Export-LMLogicModule {
                     }
                     "configsources" {
                         $LogicModuleInfo = Get-LMConfigSource -Id $LogicModuleId
+                        $ExportPath = $DownloadPath + "\$($LogicModuleInfo.name).xml"
+                        $QueryParams = "?format=xml&v=3"
+                    }
+                    "logsources" {
+                        $LogicModuleInfo = Get-LMLogSource -Id $LogicModuleId
                         $ExportPath = $DownloadPath + "\$($LogicModuleInfo.name).xml"
                         $QueryParams = "?format=xml&v=3"
                     }

--- a/Public/Get-LMAlert.ps1
+++ b/Public/Get-LMAlert.ps1
@@ -62,7 +62,7 @@ Function Get-LMAlert {
         [ValidateSet("*", "Warning", "Error", "Critical")]
         [String]$Severity = "*",
 
-        [ValidateSet("*", "websiteAlert", "dataSourceAlert", "eventSourceAlert", "logAlert")]
+        [ValidateSet("*", "websiteAlert", "dataSourceAlert", "eventAlert", "logAlert")]
         [String]$Type = "*",
 
         [Boolean]$ClearedAlerts = $false,

--- a/Public/Get-LMLogSource.ps1
+++ b/Public/Get-LMLogSource.ps1
@@ -1,0 +1,81 @@
+Function Get-LMLogSource {
+
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    Param (
+        [Parameter(ParameterSetName = 'Id')]
+        [Int]$Id,
+
+        [Parameter(ParameterSetName = 'Name')]
+        [String]$Name,
+
+        [Parameter(ParameterSetName = 'Filter')]
+        [Object]$Filter,
+
+        [ValidateRange(1, 1000)]
+        [Int]$BatchSize = 1000
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+        
+        #Build header and uri
+        $ResourcePath = "/setting/logsources"
+
+        #Initalize vars
+        $QueryParams = ""
+        $Count = 0
+        $Done = $false
+        $Results = @()
+
+        #Loop through requests 
+        While (!$Done) {
+            #Build query params
+            Switch ($PSCmdlet.ParameterSetName) {
+                "All" { $QueryParams = "?size=$BatchSize&offset=$Count&sort=+id" }
+                "Id" { $resourcePath += "/$Id" }
+                "Name" { $QueryParams = "?filter=name:`"$Name`"&size=$BatchSize&offset=$Count&sort=+id" }
+                "Filter" {
+                    #List of allowed filter props
+                    $PropList = @()
+                    $ValidFilter = Format-LMFilter -Filter $Filter -PropList $PropList
+                    $QueryParams = "?filter=$ValidFilter&size=$BatchSize&offset=$Count&sort=+id"
+                }
+            }
+            Try {
+                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
+                $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath + $QueryParams
+                    
+                
+                
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+                #Issue request
+                $Response = Invoke-RestMethod -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
+
+                #Stop looping if single device, no need to continue
+                If ($PSCmdlet.ParameterSetName -eq "Id") {
+                    $Done = $true
+                    Return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.Logsource")
+                }
+                #Check result size and if needed loop again
+                Else {
+                    [Int]$Total = $Response.Total
+                    [Int]$Count += ($Response.Items | Measure-Object).Count
+                    $Results += $Response.Items
+                    If ($Count -ge $Total) {
+                        $Done = $true
+                    }
+                }
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Return (Add-ObjectTypeInfo -InputObject $Results -TypeName "LogicMonitor.Logsource")
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/Public/Import-LMLogicModule.ps1
+++ b/Public/Import-LMLogicModule.ps1
@@ -37,7 +37,7 @@ Function Import-LMLogicModule {
         [Parameter(Mandatory, ParameterSetName = 'File')]
         [Object]$File,
         
-        [ValidateSet("datasource", "propertyrules", "eventsource", "topologysource", "configsource")]
+        [ValidateSet("datasource", "propertyrules", "eventsource", "topologysource", "configsource","logsource")]
         [String]$Type = "datasource",
 
         [Boolean]$ForceOverwrite = $false

--- a/Public/New-LMOpsNote.ps1
+++ b/Public/New-LMOpsNote.ps1
@@ -60,7 +60,7 @@ Function New-LMOpsNote {
         }
 
         $Scope = @()
-        If ($ResourceIds -or $WebsiteIds -or $DeviceGroupIds) {
+        If ($DeviceIds -or $WebsiteIds -or $DeviceGroupIds) {
             Foreach ($id in $DeviceIds) {
                 $Scope += [PSCustomObject]@{
                     type     = "device"
@@ -101,7 +101,7 @@ Function New-LMOpsNote {
             }
 
             #Remove empty keys so we dont overwrite them
-            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_])) { $Data.Remove($_) } }
+            @($Data.keys) | ForEach-Object { If ([string]::IsNullOrEmpty($Data[$_]) -and $_ -ne "scopes" -and $_ -ne "tags") { $Data.Remove($_) } }
 
             $Data = ($Data | ConvertTo-Json)
 

--- a/Public/Remove-LMLogsource.ps1
+++ b/Public/Remove-LMLogsource.ps1
@@ -1,0 +1,71 @@
+Function Remove-LMLogsource {
+
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'High')]
+    Param (
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
+        [Int]$Id,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String]$Name
+
+    )
+
+    Begin {}
+    Process {
+        #Check if we are logged in and have valid api creds
+        If ($Script:LMAuth.Valid) {
+
+            #Lookup Id if supplying username
+            If ($Name) {
+                $LookupResult = (Get-LMLogSource -Name $Name).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $Id = $LookupResult
+            }
+
+            
+            #Build header and uri
+            $ResourcePath = "/setting/logsources/$Id"
+
+            If ($PSItem) {
+                $Message = "Id: $Id | Name: $($PSItem.name)"
+            }
+            Elseif ($Name) {
+                $Message = "Id: $Id | Name: $Name"
+            }
+            Else {
+                $Message = "Id: $Id"
+            }
+
+            Try {
+                If ($PSCmdlet.ShouldProcess($Message, "Remove Logsource")) {                    
+                    $Headers = New-LMHeader -Auth $Script:LMAuth -Method "DELETE" -ResourcePath $ResourcePath
+                    $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+    
+                    Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
+
+                    #Issue request
+                    $Response = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers[0] -WebSession $Headers[1]
+                    
+                    $Result = [PSCustomObject]@{
+                        Id      = $Id
+                        Message = "Successfully removed ($Message)"
+                    }
+                    
+                    Return $Result
+                }
+            }
+            Catch [Exception] {
+                $Proceed = Resolve-LMException -LMException $PSItem
+                If (!$Proceed) {
+                    Return
+                }
+            }
+        }
+        Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    End {}
+}

--- a/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
+++ b/Public/Set-LMDeviceDatasourceInstanceAlertSetting.ps1
@@ -72,34 +72,32 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
 
             #Replace brakets in instance name
             $InstanceName = $InstanceName -replace "[\[\]]", "?"
-
             #Lookup HdsiId
             If ($DatasourceName) {
                 $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceName $DatasourceName -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id
-                If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
+                If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceName) {
                     return
                 }
                 $HdsiId = $LookupResult
             }
             Else {
                 $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -DeviceId $Id | Where-Object { $_.name -like "*$InstanceName" }).Id
-                If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
+                If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceId) {
                     return
                 }
                 $HdsiId = $LookupResult
             }
-
-            #Lookup HdsiId
-            If ($DatapointName) {
+            #Lookup DatapointId
+            If ($DatasourceName) {
                 $LookupResult = (Get-LMDeviceDatasourceInstanceAlertSetting -DatasourceName $DatasourceName -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName }).Id
-                If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
+                If (Test-LookupResult -Result $LookupResult -LookupString $DatapointName) {
                     return
                 }
                 $DatapointId = $LookupResult
             }
             Else {
-                $LookupResult = (Get-LMDeviceDatasourceInstance -DatasourceId $DatasourceId -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName }).Id
-                If (Test-LookupResult -Result $LookupResult -LookupString $InstanceName) {
+                $LookupResult = (Get-LMDeviceDatasourceInstanceAlertSetting -DatasourceId $DatasourceId -Id $Id -InstanceName $InstanceName | Where-Object { $_.dataPointName -eq $DatapointName }).Id
+                If (Test-LookupResult -Result $LookupResult -LookupString $DatasourceId) {
                     return
                 }
                 $DatapointId = $LookupResult
@@ -108,7 +106,7 @@ Function Set-LMDeviceDatasourceInstanceAlertSetting {
             #Build header and uri
             $ResourcePath = "/device/devices/$Id/devicedatasources/$HdsId/instances/$HdsiId/alertsettings/$DatapointId"
 
-            $Message = "Id: $Id | hostDatasourceId: $HdsId | datapointId: $DatapointId"
+            $Message = "Id: $Id | hostDatasourceId: $HdsId | instanceId: $HdsiId | datapointId: $DatapointId"
 
             Try {
                 $Data = @{

--- a/Public/Test-LMAppliesToQuery.ps1
+++ b/Public/Test-LMAppliesToQuery.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+Tests the applies to query against the LogicMonitor API.
+
+.DESCRIPTION
+The Test-LMAppliesToQuery function is used to test the applies to query against the LogicMonitor API.
+
+.PARAMETER Query
+The applies to query to be tested.
+
+.EXAMPLE
+Test-LMAppliesToQuery -Query "system.hostname == 'server01'"
+
+This example tests the applies to query "system.hostname == 'server01'" against the LogicMonitor API and returns a list of matching devices.
+#>
+Function Test-LMAppliesToQuery {
+
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory)]
+        [String]$Query
+
+    )
+    #Check if we are logged in and have valid api creds
+    If ($Script:LMAuth.Valid) {
+
+        
+        #Build header and uri
+        $ResourcePath = "/functions"
+
+        Try {
+            $Data = @{
+                currentAppliesTo    = $Query
+                originalAppliesTo   = $Query
+                needInheritProps    = $true
+                type                = "testAppliesTo"
+            }
+
+            $Data = ($Data | ConvertTo-Json)
+
+            $Headers = New-LMHeader -Auth $Script:LMAuth -Method "POST" -ResourcePath $ResourcePath -Data $Data 
+            $Uri = "https://$($Script:LMAuth.Portal).logicmonitor.com/santaba/rest" + $ResourcePath
+
+            Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+            #Issue request
+            $Response = (Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data).currentMatches
+
+            Return $Response
+        }
+        Catch [Exception] {
+            $Proceed = Resolve-LMException -LMException $PSItem
+            If (!$Proceed) {
+                Return
+            }
+        }
+    }
+    Else {
+        Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+    }
+}

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Get-LMAlertRule\
 Get-LMAPIToken\
 Get-LMAppliesToFunction\
 Get-LMAuditLogs\
+Get-LMAWSAccountId\
 Get-LMCachedAccount\
 Get-LMCollector\
 Get-LMCollectorDebugResult\
@@ -214,6 +215,7 @@ Get-LMCollectorGroup\
 Get-LMCollectorInstaller\
 Get-LMCollectorVersions\
 Get-LMConfigSource\
+Get-LMConfigsourceUpdateHistory\
 Get-LMDashboard\
 Get-LMDashboardGroup\
 Get-LMDashboardWidget\
@@ -229,9 +231,10 @@ Get-LMDeviceAlertSettings\
 Get-LMDeviceConfigSourceData\
 Get-LMDeviceData\
 Get-LMDeviceDatasourceInstance\
+Get-LMDeviceDatasourceInstanceAlertRecipients\
 Get-LMDeviceDatasourceInstanceAlertSetting\
 Get-LMDeviceDatasourceInstanceGroup\
-Get-LMDeviceDatasourceList\
+Get-LMDeviceDataSourceList\
 Get-LMDeviceEventSourceList\
 Get-LMDeviceGroup\
 Get-LMDeviceGroupAlerts\
@@ -253,6 +256,7 @@ Get-LMDeviceSDTHistory\
 Get-LMEscalationChain\
 Get-LMEventSource\
 Get-LMIntegrationLogs\
+Get-LMLogSource\
 Get-LMNetscan\
 Get-LMNetscanExecution\
 Get-LMNetscanExecutionDevices\
@@ -284,19 +288,24 @@ Get-LMWebsiteGroupSDTHistory\
 Get-LMWebsiteProperty\
 Get-LMWebsiteSDT\
 Get-LMWebsiteSDTHistory\
-
+\
 Import-LMDashboard\
 Import-LMExchangeModule\
 Import-LMLogicModule\
 Import-LMRepositoryLogicModules\
 \
 Invoke-LMActiveDiscovery\
+Invoke-LMAWSAccountTest\
+Invoke-LMAzureAccountTest\
+Invoke-LMAzureSubscriptionDiscovery\
 Invoke-LMCloudGroupNetScan\
 Invoke-LMCollectorDebugCommand\
 Invoke-LMDeviceConfigSourceCollection\
+Invoke-LMGCPAccountTest\
 Invoke-LMNetScan\
 Invoke-LMUserLogoff\
 \
+New-LMAccessGroup\
 New-LMAlertAck\
 New-LMAlertEscalation\
 New-LMAlertNote\
@@ -318,8 +327,8 @@ New-LMDeviceGroup\
 New-LMDeviceGroupSDT\
 New-LMDeviceProperty\
 New-LMDeviceSDT\
-New-LMEnhancedNetScan\
-New-LMNetScan\
+New-LMEnhancedNetscan\
+New-LMNetscan\
 New-LMNetscanGroup\
 New-LMOpsNote\
 New-LMPushMetricDataPoint\
@@ -330,6 +339,7 @@ New-LMUser\
 New-LMWebsite\
 New-LMWebsiteGroup\
 \
+Remove-LMAccessGroup\
 Remove-LMAPIToken\
 Remove-LMAppliesToFunction\
 Remove-LMCachedAccount\
@@ -341,8 +351,10 @@ Remove-LMDashboardWidget\
 Remove-LMDatasource\
 Remove-LMDevice\
 Remove-LMDeviceDatasourceInstance\
+Remove-LMDeviceDatasourceInstanceGroup\
 Remove-LMDeviceGroup\
 Remove-LMDeviceProperty\
+Remove-LMLogsource\
 Remove-LMNetscan\
 Remove-LMNetscanGroup\
 Remove-LMOpsNote\
@@ -360,6 +372,7 @@ Remove-LMWebsiteGroup\
 Send-LMLogMessage\
 Send-LMPushMetric\
 \
+Set-LMAccessGroup\
 Set-LMAPIToken\
 Set-LMAppliesToFunction\
 Set-LMCollector\
@@ -373,7 +386,7 @@ Set-LMDeviceDatasourceInstanceAlertSetting\
 Set-LMDeviceGroup\
 Set-LMDeviceGroupDatasourceAlertSetting\
 Set-LMDeviceProperty\
-Set-LMNetscan\
+Set-LMNetScan\
 Set-LMNetscanGroup\
 Set-LMNewUserMessage\
 Set-LMOpsNote\
@@ -387,7 +400,11 @@ Set-LMSDT\
 Set-LMTopologysource\
 Set-LMUnmonitoredDevice\
 Set-LMUser\
-Set-LMWebsite
+Set-LMUserdata\
+Set-LMWebsite\
+Set-LMWebsiteGroup\
+\
+Test-LMAppliesToQuery\
 
 **Note**: Some commands accept pipeline input, see `Get-Command <cmdlet-name> -Module Logic.Monitor` for details.
 
@@ -409,25 +426,18 @@ This change aims to enhance visibility within the community and to foster a more
 
 We appreciate your continued support and enthusiasm for the Logic.Monitor PowerShell module. Your contributions and feedback are vital to the success of this project, and we look forward to seeing how the module evolves with your participation.
 
-## 6.2
+## 6.3
 ### New Cmdlets:
- - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
- - **New-LMAccessGroup**: This cmdlet creates a new LogicMonitor access group. 
- - **Set-LMAccessGroup**: This cmdlet updates an existing LogicMonitor access group. 
- - **Remove-LMAccessGroup**: This cmdlet removes a new LogicMonitor access group. 
- - **Get-LMDeviceDatasourceInstanceAlertRecipients**: Retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
- - **Remove-LMDeviceDatasourceInstanceGroup**: Removes a LogicMonitor device datasource instance group.
- - **Set-LMDeviceDatasourceInstance**: Updates a LogicMonitor device datasource instance.
- 
- **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.
+ - **Get-LMLogSource**: This cmdlet will retrieve data for specified LogSources.
+ - **Remove-LMLogSource**: This cmdlet will remove a specified LogSource.
+ - **Test-LMAppliesToQuery**: This cmdlet will retrieve the results for a specified AppliesToQuery string, similar to the Test AppliesTo button in the portal UI.
 
 
 ### Updated Cmdlets:
- - **Get-LMDeviceDatasourceList**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
- - **Get-LMDeviceDatasourceInstance**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
- - **Get-LMDeviceDatasourceInstanceAlertSetting**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets. Also fixed bug causing an issue when trying to retrieve instances with special characters in the name.
- - **Get-LMDeviceDatasourceInstanceGroup**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
- - **Remove-LMDeviceDatasourceInstance**: Fixed bug that would prevent a datasource instance from being delete due to missing instance id.
+ - **Export-LMLogicModule**: Added support for LogSources.
+ - **Get-LMAlert**: Fixed incorrect type filter for EventSources. Issue #11
+ - **New-LMOpsNote**: Fixed bug causing device and website ID scopes to not be properly set. Issue #10
+ - **Set-LMDeviceDatasourceInstanceAlertSetting**: Fixed bug causing instance id lookup to fail when specifying instance name.
 
 
 [Previous Release Notes](RELEASENOTES.md)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,24 @@
 # Previous module release notes
+## 6.2
+### New Cmdlets:
+ - **Get-LMAccessGroup**: This cmdlet will retrieve data for specified LogicMonitor access groups. You can retrieve all access groups or limit the results using *-Id*, *-Name* or *-Filter* parameters. 
+ - **New-LMAccessGroup**: This cmdlet creates a new LogicMonitor access group. 
+ - **Set-LMAccessGroup**: This cmdlet updates an existing LogicMonitor access group. 
+ - **Remove-LMAccessGroup**: This cmdlet removes a new LogicMonitor access group. 
+ - **Get-LMDeviceDatasourceInstanceAlertRecipients**: Retrieves the alert recipients for a specific data point in a LogicMonitor device datasource instance.
+ - **Remove-LMDeviceDatasourceInstanceGroup**: Removes a LogicMonitor device datasource instance group.
+ - **Set-LMDeviceDatasourceInstance**: Updates a LogicMonitor device datasource instance.
+ 
+ **Note**: Access Groups are not available in all portals and needs to be enabled before any access group commands can be utilized.
+
+
+### Updated Cmdlets:
+ - **Get-LMDeviceDatasourceList**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
+ - **Get-LMDeviceDatasourceInstance**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
+ - **Get-LMDeviceDatasourceInstanceAlertSetting**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets. Also fixed bug causing an issue when trying to retrieve instances with special characters in the name.
+ - **Get-LMDeviceDatasourceInstanceGroup**: Added aliases *-DeviceId* and *-DeviceName* to the *-Id* and *-Name* parameters to make them inline with other cmdlets.
+ - **Remove-LMDeviceDatasourceInstance**: Fixed bug that would prevent a datasource instance from being delete due to missing instance id.
+ 
 ## 6.1
 ### New Cmdlets:
  - **Get-LMAWSAccountId**: This cmdlet is used to retrieve the AWS Account ID associated with the LogicMonitor account.


### PR DESCRIPTION
## 6.3
### New Cmdlets:
 - **Get-LMLogSource**: This cmdlet will retrieve data for specified LogSources.
 - **Remove-LMLogSource**: This cmdlet will remove a specified LogSource.
 - **Test-LMAppliesToQuery**: This cmdlet will retrieve the results for a specified AppliesToQuery string, similar to the Test AppliesTo button in the portal UI.


### Updated Cmdlets:
 - **Export-LMLogicModule**: Added support for LogSources.
 - **Get-LMAlert**: Fixed incorrect type filter for EventSources. Issue #11 
 - **New-LMOpsNote**: Fixed bug causing device and website ID scopes to not be properly set. Issue #10 
 - **Set-LMDeviceDatasourceInstanceAlertSetting**: Fixed bug causing instance id lookup to fail when specifying instance name.