### PR TITLE
79 get lmdevicedata doesnt handle paging correctly

### DIFF
--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -43,7 +43,7 @@ jobs:
           Write-Host "Powershell version: $Version"
 
           $Container = New-PesterContainer -Path ./Tests/ -Data $Data
-          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru -ExcludePath "*LMUptime*"
+          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru
 
           #Write OpsNote to test portal indicating test status
           Connect-LMAccount -AccessId $env:LM_ACCESS_ID -AccessKey $env:LM_ACCESS_KEY -AccountName $env:LM_PORTAL -DisableConsoleLogging

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -43,7 +43,7 @@ jobs:
           Write-Host "Powershell version: $Version"
 
           $Container = New-PesterContainer -Path ./Tests/ -Data $Data
-          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru
+          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru -ExcludePath "*LMUptime*"
 
           #Write OpsNote to test portal indicating test status
           Connect-LMAccount -AccessId $env:LM_ACCESS_ID -AccessKey $env:LM_ACCESS_KEY -AccountName $env:LM_PORTAL -DisableConsoleLogging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           Write-Host "Powershell version: $Version"
 
           $Container = New-PesterContainer -Path ./Tests/ -Data $Data
-          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru -ExcludePath "*LMUptime*"
+          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru
 
           #Write OpsNote to test portal indicating test status
           Connect-LMAccount -AccessId $env:LM_ACCESS_ID -AccessKey $env:LM_ACCESS_KEY -AccountName $env:LM_PORTAL -DisableConsoleLogging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           Write-Host "Powershell version: $Version"
 
           $Container = New-PesterContainer -Path ./Tests/ -Data $Data
-          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru
+          $Result = Invoke-Pester -Container $Container -Output Detailed -PassThru -ExcludePath "*LMUptime*"
 
           #Write OpsNote to test portal indicating test status
           Connect-LMAccount -AccessId $env:LM_ACCESS_ID -AccessKey $env:LM_ACCESS_KEY -AccountName $env:LM_PORTAL -DisableConsoleLogging

--- a/Documentation/Get-LMDeviceData.md
+++ b/Documentation/Get-LMDeviceData.md
@@ -15,56 +15,56 @@ Retrieves monitoring data for a LogicMonitor device.
 ### dsName-deviceName-instanceId
 ```
 Get-LMDeviceData -DatasourceName <String> -DeviceName <String> -InstanceId <Int32> [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsName-deviceName-instanceName
 ```
 Get-LMDeviceData -DatasourceName <String> -DeviceName <String> [-InstanceName <String>] [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsName-deviceId-instanceName
 ```
 Get-LMDeviceData -DatasourceName <String> -DeviceId <Int32> [-InstanceName <String>] [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsName-deviceId-instanceId
 ```
 Get-LMDeviceData -DatasourceName <String> -DeviceId <Int32> -InstanceId <Int32> [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsId-deviceName-instanceId
 ```
 Get-LMDeviceData -DatasourceId <Int32> -DeviceName <String> -InstanceId <Int32> [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsId-deviceName-instanceName
 ```
 Get-LMDeviceData -DatasourceId <Int32> -DeviceName <String> [-InstanceName <String>] [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsId-deviceId-instanceName
 ```
 Get-LMDeviceData -DatasourceId <Int32> -DeviceId <Int32> [-InstanceName <String>] [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
 ### dsId-deviceId-instanceId
 ```
 Get-LMDeviceData -DatasourceId <Int32> -DeviceId <Int32> -InstanceId <Int32> [-StartDate <DateTime>]
- [-EndDate <DateTime>] [-Filter <Object>] [-BatchSize <Int32>] [-ProgressAction <ActionPreference>]
+ [-EndDate <DateTime>] [-Filter <Object>] [-Datapoints <String>] [-ProgressAction <ActionPreference>]
  [<CommonParameters>]
 ```
 
@@ -76,8 +76,8 @@ It supports various combinations of identifying the device, datasource, and inst
 
 ### EXAMPLE 1
 ```
-#Retrieve data using IDs
-Get-LMDeviceData -DeviceId 123 -DatasourceId 456 -InstanceId 789
+#Retrieve data using IDs for datapoints "cpu" and "memory"
+Get-LMDeviceData -DeviceId 123 -DatasourceId 456 -InstanceId 789 -Datapoints "cpu,memory"
 ```
 
 ### EXAMPLE 2
@@ -232,19 +232,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -BatchSize
-The number of results to return per request.
-Must be between 1 and 1000.
-Defaults to 1000.
+### -Datapoints
+Comma separated list of datapoints to retrieve.
+If not provided, all datapoints will be retrieved.
 
 ```yaml
-Type: Int32
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: 1000
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Documentation/Set-LMAWSDiscoverySettings.md
+++ b/Documentation/Set-LMAWSDiscoverySettings.md
@@ -1,0 +1,252 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Set-LMAWSDiscoverySettings
+
+## SYNOPSIS
+Updates AWS Cloud discovery settings for specified AWS accounts in LogicMonitor.
+
+## SYNTAX
+
+### Id (Default)
+```
+Set-LMAWSDiscoverySettings -AccountId <Int32> -ServiceName <String> -Regions <String[]> [-AutoDelete <Boolean>]
+ [-DeleteDelayDays <Int32>] [-DisableAlerting <Boolean>] [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### Name
+```
+Set-LMAWSDiscoverySettings -Name <String> -ServiceName <String> -Regions <String[]> [-AutoDelete <Boolean>]
+ [-DeleteDelayDays <Int32>] [-DisableAlerting <Boolean>] [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### Csv
+```
+Set-LMAWSDiscoverySettings -CsvPath <String> -ServiceName <String> -Regions <String[]> [-AutoDelete <Boolean>]
+ [-DeleteDelayDays <Int32>] [-DisableAlerting <Boolean>] [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-LMAWSDiscoverySettings function modifies AWS Cloud discovery settings such as monitored regions, automatic deletion policies, and alerting preferences for AWS services within LogicMonitor.
+The function supports updating a single AWS account by AccountId or multiple accounts by importing AccountIds from a CSV file.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-LMAWSDiscoverySettings -AccountId 317 -ServiceName "EC2" -Regions "us-east-1","us-west-2"
+Updates EC2 discovery settings for AWS account group ID 317 to monitor only us-east-1 and us-west-2 regions.
+```
+
+### EXAMPLE 2
+```
+Set-LMAWSDiscoverySettings -Name "Production AWS Account" -ServiceName "RDS" -Regions "us-east-1","us-east-2" -AutoDelete -DeleteDelayDays 10
+Updates RDS discovery settings for the AWS account named "Production AWS Account" with automatic deletion enabled after 10 days.
+```
+
+### EXAMPLE 3
+```
+Set-LMAWSDiscoverySettings -CsvPath "C:\aws_accounts.csv" -ServiceName "EC2" -Regions "us-east-1","us-east-2"
+Bulk updates EC2 discovery settings for multiple AWS accounts listed in the CSV file.
+```
+
+### EXAMPLE 4
+```
+Set-LMAWSDiscoverySettings -AccountId 317 -ServiceName "Lambda" -Regions "us-east-1" -AutoDelete -DeleteDelayDays 5 -DisableAlerting
+Updates Lambda discovery settings with automatic deletion after 5 days and alerting disabled on termination.
+```
+
+## PARAMETERS
+
+### -AccountId
+Specifies the LogicMonitor device group ID of the AWS account for which to update discovery settings.
+This parameter is mandatory when using the 'Id' parameter set.
+
+```yaml
+Type: Int32
+Parameter Sets: Id
+Aliases: Id
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name of the AWS account device group.
+This parameter is mandatory when using the 'Name' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Name
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CsvPath
+Specifies the path to a CSV file containing multiple AWS AccountIds to update in bulk.
+The CSV must have an "AccountId" column.
+This parameter is part of the 'Csv' parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Csv
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServiceName
+Specifies the AWS service name (e.g., "EC2", "RDS", "Lambda") whose discovery settings are to be updated.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Regions
+Specifies an array of AWS regions (e.g., "us-east-1","us-east-2") to monitor for the specified service.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AutoDelete
+Specifies whether to enable automatic deletion of terminated AWS resources.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeleteDelayDays
+Specifies the number of days to wait before automatically deleting terminated resources.
+Defaults to 7.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableAlerting
+Specifies whether to disable alerting automatically after resource termination.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### You can pipe objects containing AccountId properties to this function.
+## OUTPUTS
+
+### Returns a LogicMonitor.DeviceGroup object containing the updated AWS account group information.
+## NOTES
+This function requires a valid LogicMonitor API authentication.
+Use Connect-LMAccount before running this command.
+
+## RELATED LINKS

--- a/Documentation/Set-LMDeviceGroupDatasource.md
+++ b/Documentation/Set-LMDeviceGroupDatasource.md
@@ -1,0 +1,199 @@
+---
+external help file: Logic.Monitor-help.xml
+Module Name: Logic.Monitor
+online version:
+schema: 2.0.0
+---
+
+# Set-LMDeviceGroupDatasource
+
+## SYNOPSIS
+Updates a LogicMonitor device group datasource configuration.
+
+## SYNTAX
+
+### Name-dsName
+```
+Set-LMDeviceGroupDatasource -DatasourceName <String> -Name <String> [-StopMonitoring <Boolean>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Id-dsName
+```
+Set-LMDeviceGroupDatasource -DatasourceName <String> -Id <Int32> [-StopMonitoring <Boolean>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Name-dsId
+```
+Set-LMDeviceGroupDatasource -DatasourceId <Int32> -Name <String> [-StopMonitoring <Boolean>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### Id-dsId
+```
+Set-LMDeviceGroupDatasource -DatasourceId <Int32> -Id <Int32> [-StopMonitoring <Boolean>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Set-LMDeviceGroupDatasource cmdlet modifies an existing device group datasource in LogicMonitor, allowing updates to monitoring state.
+This cmdlet provides control over the "Enable" checkbox (stopMonitoring) for a datasource applied to a device group.
+For alert settings use Set-LMDeviceGroupDatasourceAlertSetting.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+#Disable monitoring for a datasource on a device group
+Set-LMDeviceGroupDatasource -Id 15 -DatasourceId 790 -StopMonitoring $true
+```
+
+### EXAMPLE 2
+```
+#Enable monitoring using names
+Set-LMDeviceGroupDatasource -Name "Production Servers" -DatasourceName "CPU" -StopMonitoring $false
+```
+
+## PARAMETERS
+
+### -DatasourceName
+Specifies the name of the datasource.
+Required when using the 'Id-dsName' or 'Name-dsName' parameter sets.
+
+```yaml
+Type: String
+Parameter Sets: Name-dsName, Id-dsName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DatasourceId
+Specifies the ID of the datasource.
+Required when using the 'Id-dsId' or 'Name-dsId' parameter sets.
+
+```yaml
+Type: Int32
+Parameter Sets: Name-dsId, Id-dsId
+Aliases:
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies the ID of the device group.
+Required when using the 'Id-dsId' or 'Id-dsName' parameter sets.
+
+```yaml
+Type: Int32
+Parameter Sets: Id-dsName, Id-dsId
+Aliases:
+
+Required: True
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name of the device group.
+Required when using the 'Name-dsId' or 'Name-dsName' parameter sets.
+
+```yaml
+Type: String
+Parameter Sets: Name-dsName, Name-dsId
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StopMonitoring
+Specifies whether to stop monitoring the datasource.
+When set to $true, monitoring is disabled (unchecks the "Enable" checkbox).
+When set to $false, monitoring is enabled (checks the "Enable" checkbox).
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None. You cannot pipe objects to this command.
+## OUTPUTS
+
+### Returns a LogicMonitor.DeviceGroupDatasource object containing the updated datasource configuration.
+## NOTES
+You must run Connect-LMAccount before running this command.
+
+## RELATED LINKS

--- a/Private/Resolve-LMUptimeTestLocation.ps1
+++ b/Private/Resolve-LMUptimeTestLocation.ps1
@@ -66,11 +66,23 @@ function Resolve-LMUptimeTestLocation {
     }
 
     if ($collectorSpecified) {
-        $testLocation.collectorIds = @($TestLocationCollectorIds)
+        # Ensure it's always an array, even with a single item
+        if ($TestLocationCollectorIds) {
+            $testLocation.collectorIds = @($TestLocationCollectorIds)
+        }
+        else {
+            $testLocation.collectorIds = @()
+        }
     }
 
     if ($smgSpecified) {
-        $testLocation.smgIds = @($TestLocationSmgIds)
+        # Ensure it's always an array, even with a single item
+        if ($TestLocationSmgIds) {
+            $testLocation.smgIds = @($TestLocationSmgIds)
+        }
+        else {
+            $testLocation.smgIds = @()
+        }
     }
 
     if ($allSpecified) {

--- a/Public/Get-LMDeviceData.ps1
+++ b/Public/Get-LMDeviceData.ps1
@@ -36,8 +36,8 @@ Comma separated list of datapoints to retrieve. If not provided, all datapoints 
 A filter object to apply when retrieving data. This parameter is optional.
 
 .EXAMPLE
-#Retrieve data using IDs
-Get-LMDeviceData -DeviceId 123 -DatasourceId 456 -InstanceId 789
+#Retrieve data using IDs for datapoints "cpu" and "memory"
+Get-LMDeviceData -DeviceId 123 -DatasourceId 456 -InstanceId 789 -Datapoints "cpu,memory"
 
 .EXAMPLE
 #Retrieve data using names with time range

--- a/Public/Get-LMDeviceData.ps1
+++ b/Public/Get-LMDeviceData.ps1
@@ -29,11 +29,11 @@ The start date and time for data collection. Defaults to 7 days ago if not speci
 .PARAMETER EndDate
 The end date and time for data collection. Defaults to current time if not specified.
 
+.PARAMETER Datapoints
+Comma separated list of datapoints to retrieve. If not provided, all datapoints will be retrieved.
+
 .PARAMETER Filter
 A filter object to apply when retrieving data. This parameter is optional.
-
-.PARAMETER BatchSize
-The number of results to return per request. Must be between 1 and 1000. Defaults to 1000.
 
 .EXAMPLE
 #Retrieve data using IDs
@@ -98,8 +98,7 @@ function Get-LMDeviceData {
 
         [Object]$Filter,
 
-        [ValidateRange(1, 1000)]
-        [Int]$BatchSize = 1000
+        [String]$Datapoints
 
     )
     #Check if we are logged in and have valid api creds
@@ -160,63 +159,76 @@ function Get-LMDeviceData {
 
         #Initalize vars
         $QueryParams = ""
-        $Count = 0
         $Done = $false
-        $Results = @()
+        $AllDatapoints = @()
+        $AllValues = @()
+        $AllTimes = @()
 
-        #Loop through requests
+        #Loop through requests using nextPageParams
         while (!$Done) {
-            #Build query params
-            $QueryParams = "?size=$BatchSize&offset=$Count&sort=+id"
+            #Build query params - start with empty or use nextPageParams from previous response
+            if (!$QueryParams) {
+                $QueryParams = "?"
+                
+                #Add time range filter if provided data ranges
+                if ($StartDate -and $EndDate) {
+                    $QueryParams = $QueryParams + "start=$StartDate&end=$EndDate"
+                }
 
-            if ($Filter) {
-                    $ValidFilter = Format-LMFilter -Filter $Filter -ResourcePath $ResourcePath
-                $QueryParams = "?filter=$ValidFilter&size=$BatchSize&offset=$Count&sort=+id"
+                #Add datapoints filter if provided
+                if ($Datapoints) {
+                    if ($QueryParams -ne "?") {
+                        $QueryParams = $QueryParams + "&"
+                    }
+                    $QueryParams = $QueryParams + "datapoints=$Datapoints"
+                }
+
+                #Remove trailing ? if no params were added
+                if ($QueryParams -eq "?") {
+                    $QueryParams = ""
+                }
             }
 
-            #Add time range filter if provided data ranges
-            if ($StartDate -and $EndDate) {
-                $QueryParams = $QueryParams + "&start=$StartDate&end=$EndDate"
-            }
-
-            
             $Headers = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
             $Uri = "https://$($Script:LMAuth.Portal).$(Get-LMPortalURI)" + $ResourcePath + $QueryParams
-
-
 
             Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation
 
             #Issue request
             $Response = Invoke-LMRestMethod -CallerPSCmdlet $PSCmdlet -Uri $Uri -Method "GET" -Headers $Headers[0] -WebSession $Headers[1]
 
-            #Stop looping if single device, no need to continue
-            if (![bool]$Response.psobject.Properties["total"]) {
-                $Done = $true
+            #Collect data from this page
+            if ($Response.values) {
+                $AllValues += $Response.values
             }
-            #Check result size and if needed loop again
+            if ($Response.time) {
+                $AllTimes += $Response.time
+            }
+            if ($Response.dataPoints -and $AllDatapoints.Count -eq 0) {
+                $AllDatapoints = $Response.dataPoints
+            }
+
+            #Check if there are more pages using nextPageParams
+            if ($Response.nextPageParams) {
+                $QueryParams = "?$($Response.nextPageParams)"
+            }
             else {
-                [Int]$Total = $Response.Total
-                [Int]$Count += ($Response.Items | Measure-Object).Count
-                $Results += $Response.Items
-                if ($Count -ge $Total) {
-                    $Done = $true
-                }
+                $Done = $true
             }
 
         }
         #Convert results into readable format for consumption
-        if ($Response) {
-            $DatapointResults = @($null) * ($Response.values | Measure-Object).Count
-            for ($v = 0 ; $v -lt ($Response.values | Measure-Object).Count ; $v++) {
+        if ($AllValues.Count -gt 0) {
+            $DatapointResults = @($null) * $AllValues.Count
+            for ($v = 0 ; $v -lt $AllValues.Count ; $v++) {
                 $DatapointResults[$v] = [PSCustomObject]@{}
-                $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampEpoch" -Value $Response.time[$v]
+                $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampEpoch" -Value $AllTimes[$v]
 
-                $TimestampConverted = (([System.DateTimeOffset]::FromUnixTimeMilliseconds($Response.time[$v])).DateTime).ToString()
+                $TimestampConverted = (([System.DateTimeOffset]::FromUnixTimeMilliseconds($AllTimes[$v])).DateTime).ToString()
                 $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name "TimestampUTC" -Value $TimestampConverted
 
-                for ($dp = 0 ; $dp -lt ($Response.dataPoints | Measure-Object).Count; $dp++) {
-                    $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name $Response.dataPoints[$dp] -Value $Response.values[$v][$dp]
+                for ($dp = 0 ; $dp -lt $AllDatapoints.Count; $dp++) {
+                    $DatapointResults[$v] | Add-Member -MemberType NoteProperty -Name $AllDatapoints[$dp] -Value $AllValues[$v][$dp]
                 }
             }
             return $DatapointResults

--- a/Public/Set-LMAWSDiscoverySettings.ps1
+++ b/Public/Set-LMAWSDiscoverySettings.ps1
@@ -1,0 +1,281 @@
+<#
+.SYNOPSIS
+Updates AWS Cloud discovery settings for specified AWS accounts in LogicMonitor.
+
+.DESCRIPTION
+The Set-LMAWSDiscoverySettings function modifies AWS Cloud discovery settings such as monitored regions, automatic deletion policies, and alerting preferences for AWS services within LogicMonitor. The function supports updating a single AWS account by AccountId or multiple accounts by importing AccountIds from a CSV file.
+
+.PARAMETER AccountId
+Specifies the LogicMonitor device group ID of the AWS account for which to update discovery settings. This parameter is mandatory when using the 'Id' parameter set.
+
+.PARAMETER Name
+Specifies the name of the AWS account device group. This parameter is mandatory when using the 'Name' parameter set.
+
+.PARAMETER ServiceName
+Specifies the AWS service name (e.g., "EC2", "RDS", "Lambda") whose discovery settings are to be updated.
+
+.PARAMETER Regions
+Specifies an array of AWS regions (e.g., "us-east-1","us-east-2") to monitor for the specified service.
+
+.PARAMETER CsvPath
+Specifies the path to a CSV file containing multiple AWS AccountIds to update in bulk. The CSV must have an "AccountId" column. This parameter is part of the 'Csv' parameter set.
+
+.PARAMETER AutoDelete
+Specifies whether to enable automatic deletion of terminated AWS resources.
+
+.PARAMETER DeleteDelayDays
+Specifies the number of days to wait before automatically deleting terminated resources. Defaults to 7.
+
+.PARAMETER DisableAlerting
+Specifies whether to disable alerting automatically after resource termination.
+
+.EXAMPLE
+Set-LMAWSDiscoverySettings -AccountId 317 -ServiceName "EC2" -Regions "us-east-1","us-west-2"
+Updates EC2 discovery settings for AWS account group ID 317 to monitor only us-east-1 and us-west-2 regions.
+
+.EXAMPLE
+Set-LMAWSDiscoverySettings -Name "Production AWS Account" -ServiceName "RDS" -Regions "us-east-1","us-east-2" -AutoDelete -DeleteDelayDays 10
+Updates RDS discovery settings for the AWS account named "Production AWS Account" with automatic deletion enabled after 10 days.
+
+.EXAMPLE
+Set-LMAWSDiscoverySettings -CsvPath "C:\aws_accounts.csv" -ServiceName "EC2" -Regions "us-east-1","us-east-2"
+Bulk updates EC2 discovery settings for multiple AWS accounts listed in the CSV file.
+
+.EXAMPLE
+Set-LMAWSDiscoverySettings -AccountId 317 -ServiceName "Lambda" -Regions "us-east-1" -AutoDelete -DeleteDelayDays 5 -DisableAlerting
+Updates Lambda discovery settings with automatic deletion after 5 days and alerting disabled on termination.
+
+.INPUTS
+You can pipe objects containing AccountId properties to this function.
+
+.OUTPUTS
+Returns a LogicMonitor.DeviceGroup object containing the updated AWS account group information.
+
+.NOTES
+This function requires a valid LogicMonitor API authentication. Use Connect-LMAccount before running this command.
+#>
+function Set-LMAWSDiscoverySettings {
+
+    [CmdletBinding(DefaultParameterSetName = 'Id', SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Id', ValueFromPipelineByPropertyName)]
+        [Alias('Id')]
+        [Int]$AccountId,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [String]$Name,
+
+        [Parameter(Mandatory, ParameterSetName = 'Csv')]
+        [ValidateScript({ Test-Path $_ })]
+        [String]$CsvPath,
+
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [Parameter(Mandatory, ParameterSetName = 'Csv')]
+        [String]$ServiceName,
+
+        [Parameter(Mandatory, ParameterSetName = 'Id')]
+        [Parameter(Mandatory, ParameterSetName = 'Name')]
+        [Parameter(Mandatory, ParameterSetName = 'Csv')]
+        [String[]]$Regions,
+
+        [Parameter(ParameterSetName = 'Id')]
+        [Parameter(ParameterSetName = 'Name')]
+        [Parameter(ParameterSetName = 'Csv')]
+        [Nullable[Boolean]]$AutoDelete,
+
+        [Parameter(ParameterSetName = 'Id')]
+        [Parameter(ParameterSetName = 'Name')]
+        [Parameter(ParameterSetName = 'Csv')]
+        [ValidateRange(1, 365)]
+        [Nullable[Int]]$DeleteDelayDays,
+
+        [Parameter(ParameterSetName = 'Id')]
+        [Parameter(ParameterSetName = 'Name')]
+        [Parameter(ParameterSetName = 'Csv')]
+        [Nullable[Boolean]]$DisableAlerting
+    )
+
+    begin {}
+    process {
+        # Handle CSV bulk processing
+        if ($PSCmdlet.ParameterSetName -eq 'Csv') {
+            $csv = Import-Csv -Path $CsvPath
+            $accountIds = $csv.AccountId | Where-Object { $_ } | Sort-Object -Unique
+            
+            if ($accountIds.Count -eq 0) {
+                Write-Error "No valid AccountId values found in CSV file: $CsvPath"
+                return
+            }
+
+            Write-Verbose "Processing $($accountIds.Count) AWS account(s) from CSV file"
+
+            foreach ($id in $accountIds) {
+                if ($id -notmatch '^\d+$') {
+                    Write-Warning "Skipping invalid AccountId value: $id"
+                    continue
+                }
+
+                $params = @{
+                    AccountId   = [Int]$id
+                    ServiceName = $ServiceName
+                    Regions     = $Regions
+                }
+                
+                if ($PSBoundParameters.ContainsKey('AutoDelete')) { $params['AutoDelete'] = $AutoDelete }
+                if ($PSBoundParameters.ContainsKey('DeleteDelayDays')) { $params['DeleteDelayDays'] = $DeleteDelayDays }
+                if ($PSBoundParameters.ContainsKey('DisableAlerting')) { $params['DisableAlerting'] = $DisableAlerting }
+
+                try {
+                    Set-LMAWSDiscoverySettings @params
+                }
+                catch {
+                    Write-Warning "Failed to update account ID ${id}: $_"
+                }
+            }
+            return
+        }
+
+        # Check if we are logged in and have valid api creds
+        if ($Script:LMAuth.Valid) {
+
+            # Lookup AccountId by Name if needed
+            if ($Name) {
+                $LookupResult = (Get-LMDeviceGroup -Name $Name).Id
+                if (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $AccountId = $LookupResult
+            }
+
+            # Build header and uri
+            $ResourcePath = "/device/groups/$AccountId"
+
+            if ($PSItem) {
+                $Message = "Id: $AccountId | Name: $($PSItem.name) | Service: $ServiceName"
+            }
+            elseif ($Name) {
+                $Message = "Id: $AccountId | Name: $Name | Service: $ServiceName"
+            }
+            else {
+                $Message = "Id: $AccountId | Service: $ServiceName"
+            }
+
+            # Retrieve current AWS account group configuration
+            try {
+                Write-Verbose "Retrieving AWS account group configuration for ID $AccountId"
+                
+                $GetHeaders = New-LMHeader -Auth $Script:LMAuth -Method "GET" -ResourcePath $ResourcePath
+                $GetUri = "https://$($Script:LMAuth.Portal).$(Get-LMPortalURI)" + $ResourcePath
+
+                Resolve-LMDebugInfo -Url $GetUri -Headers $GetHeaders[0] -Command $MyInvocation
+
+                $Response = Invoke-LMRestMethod -CallerPSCmdlet $PSCmdlet -Uri $GetUri -Method "GET" -Headers $GetHeaders[0] -WebSession $GetHeaders[1]
+
+                if (-not $Response) {
+                    Write-Error "Failed to retrieve AWS account group with ID $AccountId"
+                    return
+                }
+
+                # Validate that this is an AWS account group
+                if ($Response.groupType -notmatch '^AWS/') {
+                    Write-Error "Device group ID $AccountId is not an AWS account group (Type: $($Response.groupType))"
+                    return
+                }
+
+                # Validate service exists
+                if (-not $Response.extra.services) {
+                    Write-Error "No AWS services configuration found for account group ID $AccountId"
+                    return
+                }
+
+                # Find the service (case-insensitive)
+                $serviceKey = $Response.extra.services.PSObject.Properties.Name | 
+                    Where-Object { $_.ToLower() -eq $ServiceName.ToLower() } | 
+                    Select-Object -First 1
+
+                if (-not $serviceKey) {
+                    $availableServices = $Response.extra.services.PSObject.Properties.Name -join ', '
+                    Write-Error "Service '$ServiceName' not found for account ID $AccountId. Available services: $availableServices"
+                    return
+                }
+
+                Write-Verbose "Found service '$serviceKey' in AWS account group"
+
+                # Get current service configuration
+                $serviceConfig = $Response.extra.services.$serviceKey
+
+                # Handle inheritance from default settings
+                if ($serviceConfig.useDefault -eq $true) {
+                    Write-Verbose "Service '$serviceKey' currently inherits from global settings. Switching to custom settings."
+                    $serviceConfig.useDefault = $false
+                }
+
+                # Update service configuration with new values
+                $serviceConfig.monitoringRegions = $Regions
+
+                if ($PSBoundParameters.ContainsKey('AutoDelete')) {
+                    $serviceConfig.isAutomaticDeletionEnabled = $AutoDelete
+                }
+
+                if ($PSBoundParameters.ContainsKey('DisableAlerting')) {
+                    $serviceConfig.isAlertingAutomaticallyDisabledAfterTermination = $DisableAlerting
+                }
+
+                if ($PSBoundParameters.ContainsKey('DeleteDelayDays')) {
+                    if (-not $serviceConfig.automaticallyDeleteTerminatedResourcesOffset) {
+                        $serviceConfig | Add-Member -NotePropertyName 'automaticallyDeleteTerminatedResourcesOffset' -NotePropertyValue @{} -Force
+                    }
+                    $serviceConfig.automaticallyDeleteTerminatedResourcesOffset.units = "DAYS"
+                    $serviceConfig.automaticallyDeleteTerminatedResourcesOffset.offset = $DeleteDelayDays
+                }
+
+                # Update the service in the response object
+                $Response.extra.services.$serviceKey = $serviceConfig
+
+                # Build the data payload for PATCH (send the entire extra object)
+                $Data = @{
+                    extra = $Response.extra
+                } | ConvertTo-Json -Depth 10
+
+                if ($PSCmdlet.ShouldProcess($Message, "Update AWS Discovery Settings")) {
+                    
+                    $Headers = New-LMHeader -Auth $Script:LMAuth -Method "PATCH" -ResourcePath $ResourcePath -Data $Data
+                    $Uri = "https://$($Script:LMAuth.Portal).$(Get-LMPortalURI)" + $ResourcePath
+
+                    Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                    # Issue request using centralized method with retry logic
+                    $PatchResponse = Invoke-LMRestMethod -CallerPSCmdlet $PSCmdlet -Uri $Uri -Method "PATCH" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                    Write-Verbose "Successfully updated AWS discovery settings for service '$serviceKey' in account ID $AccountId"
+
+                    return (Add-ObjectTypeInfo -InputObject $PatchResponse -TypeName "LogicMonitor.DeviceGroup")
+                }
+            }
+            catch {
+                $errorMessage = $_.Exception.Message
+
+                # Handle known non-fatal API warnings
+                if ($errorMessage -match "Permissions are insufficient|Please see https://www\.logicmonitor\.com/support/lm-cloud") {
+                    Write-Warning "Non-fatal LogicMonitor API warning: $errorMessage"
+                    Write-Verbose "Settings may have been partially applied. Verify configuration in LogicMonitor portal."
+                    
+                    # Still return the response if we have it
+                    if ($PatchResponse) {
+                        return (Add-ObjectTypeInfo -InputObject $PatchResponse -TypeName "LogicMonitor.DeviceGroup")
+                    }
+                    return
+                }
+                else {
+                    # Re-throw for proper error handling
+                    throw
+                }
+            }
+        }
+        else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    end {}
+}

--- a/Public/Set-LMDeviceGroupDatasource.ps1
+++ b/Public/Set-LMDeviceGroupDatasource.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+Updates a LogicMonitor device group datasource configuration.
+
+.DESCRIPTION
+The Set-LMDeviceGroupDatasource cmdlet modifies an existing device group datasource in LogicMonitor, allowing updates to monitoring state. This cmdlet provides control over the "Enable" checkbox (stopMonitoring) for a datasource applied to a device group. For alert settings use Set-LMDeviceGroupDatasourceAlertSetting.
+
+.PARAMETER DatasourceName
+Specifies the name of the datasource. Required when using the 'Id-dsName' or 'Name-dsName' parameter sets.
+
+.PARAMETER DatasourceId
+Specifies the ID of the datasource. Required when using the 'Id-dsId' or 'Name-dsId' parameter sets.
+
+.PARAMETER Id
+Specifies the ID of the device group. Required when using the 'Id-dsId' or 'Id-dsName' parameter sets.
+
+.PARAMETER Name
+Specifies the name of the device group. Required when using the 'Name-dsId' or 'Name-dsName' parameter sets.
+
+.PARAMETER StopMonitoring
+Specifies whether to stop monitoring the datasource. When set to $true, monitoring is disabled (unchecks the "Enable" checkbox). When set to $false, monitoring is enabled (checks the "Enable" checkbox).
+
+.EXAMPLE
+#Disable monitoring for a datasource on a device group
+Set-LMDeviceGroupDatasource -Id 15 -DatasourceId 790 -StopMonitoring $true
+
+.EXAMPLE
+#Enable monitoring using names
+Set-LMDeviceGroupDatasource -Name "Production Servers" -DatasourceName "CPU" -StopMonitoring $false 
+
+.INPUTS
+None. You cannot pipe objects to this command.
+
+.OUTPUTS
+Returns a LogicMonitor.DeviceGroupDatasource object containing the updated datasource configuration.
+
+.NOTES
+You must run Connect-LMAccount before running this command.
+#>
+
+function Set-LMDeviceGroupDatasource {
+
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'None')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [String]$DatasourceName,
+
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [Int]$DatasourceId,
+
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsId')]
+        [Parameter(Mandatory, ParameterSetName = 'Id-dsName')]
+        [Int]$Id,
+
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsName')]
+        [Parameter(Mandatory, ParameterSetName = 'Name-dsId')]
+        [String]$Name,
+
+        [Nullable[boolean]]$StopMonitoring
+
+    )
+
+    begin {}
+    process {
+        #Check if we are logged in and have valid api creds
+        if ($Script:LMAuth.Valid) {
+
+            #Lookup DeviceGroupId
+            if ($Name) {
+                $LookupResult = (Get-LMDeviceGroup -Name $Name).Id
+                if (Test-LookupResult -Result $LookupResult -LookupString $Name) {
+                    return
+                }
+                $Id = $LookupResult
+            }
+
+            #Lookup DatasourceId
+            if ($DatasourceName) {
+                $LookupResult = (Get-LMDatasource -Name $DatasourceName).Id
+                if (Test-LookupResult -Result $LookupResult -LookupString $DatasourceName) {
+                    return
+                }
+                $DatasourceId = $LookupResult
+            }
+
+            #Build header and uri
+            $ResourcePath = "/device/groups/$Id/datasources/$DatasourceId"
+
+            if ($Name) {
+                $Message = "Id: $Id | Name: $Name | DatasourceId: $DatasourceId"
+            }
+            else {
+                $Message = "Id: $Id | DatasourceId: $DatasourceId"
+            }
+
+            
+            $Data = @{
+                stopMonitoring  = $StopMonitoring
+            }
+
+            #Remove empty keys so we dont overwrite them
+            $Data = Format-LMData `
+                -Data $Data `
+                -UserSpecifiedKeys $MyInvocation.BoundParameters.Keys
+
+            if ($PSCmdlet.ShouldProcess($Message, "Set Device Group Datasource")) {
+                $Headers = New-LMHeader -Auth $Script:LMAuth -Method "PATCH" -ResourcePath $ResourcePath -Data $Data
+                $Uri = "https://$($Script:LMAuth.Portal).$(Get-LMPortalURI)" + $ResourcePath
+
+                Resolve-LMDebugInfo -Url $Uri -Headers $Headers[0] -Command $MyInvocation -Payload $Data
+
+                #Issue request
+                $Response = Invoke-LMRestMethod -CallerPSCmdlet $PSCmdlet -Uri $Uri -Method "PATCH" -Headers $Headers[0] -WebSession $Headers[1] -Body $Data
+
+                return (Add-ObjectTypeInfo -InputObject $Response -TypeName "LogicMonitor.DeviceGroupDatasource" )
+            }
+
+        }
+        else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+        }
+    }
+    end {}
+}
+

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Connect-LMAccount -UseCachedCredential
 
 ### New Cmdlets
 - **Set-LMDeviceGroupDatasource**: This cmdlet modifies an existing device group datasource in LogicMonitor, allowing updates to monitoring state. This cmdlet provides control over the "Enable" checkbox (stopMonitoring) for a datasource applied to a device group. For alert settings use *Set-LMDeviceGroupDatasourceAlertSetting*.
+
+### Important Notes
+- **LM Uptime Removal**: Due to issues with the v3 api endpoints for LM Uptime, they are being temporarily removed from the module. As soon as they are officially supported in the LM Swagger guide they will be reintroduced along with the Website->Uptime conversion cmdlet. For previous versions of the module that still have access to these cmdlets it is recommended that you wait until the official swagger endpoints are released.
 ---
 
 ### Major Changes in v7:

--- a/README.md
+++ b/README.md
@@ -73,15 +73,13 @@ Connect-LMAccount -UseCachedCredential
 
 # Change List
 
-## 7.7.4
-### Hotfixes
-- **Invoke-LMCollectorDebugCommand**: Fixed bug where *-GroovyCommand* would fail to execute when given an inline groovy snippet.
+## 7.7.5
+### Cmdlet Changes
+- **Get-LMDeviceData**: Fixed a bug that used the incorrect pagination logic when trying to enumerate additional pages of result data.
+- **Get-LMDeviceData**: Added a new parameter *-Datapoints* which allows for filtering which datapoints are returned as part of the data export.
 
-## 7.7.3
-### Hotfixes
-- **New-LMAlertRule**: Fixed bug where datapoint, instance and datasource where not properly being set due to a change in the field names.
-- **Set-LMAlertRule**: Fixed bug where datapoint, instance and datasource where not properly being set due to a change in the field names.
-
+### New Cmdlets
+- **Set-LMDeviceGroupDatasource**: This cmdlet modifies an existing device group datasource in LogicMonitor, allowing updates to monitoring state. This cmdlet provides control over the "Enable" checkbox (stopMonitoring) for a datasource applied to a device group. For alert settings use *Set-LMDeviceGroupDatasourceAlertSetting*.
 ---
 
 ### Major Changes in v7:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,13 @@
 # Previous module release notes
+## 7.7.4
+### Hotfixes
+- **Invoke-LMCollectorDebugCommand**: Fixed bug where *-GroovyCommand* would fail to execute when given an inline groovy snippet.
+
+## 7.7.3
+### Hotfixes
+- **New-LMAlertRule**: Fixed bug where datapoint, instance and datasource where not properly being set due to a change in the field names.
+- **Set-LMAlertRule**: Fixed bug where datapoint, instance and datasource where not properly being set due to a change in the field names.
+
 ## 7.7.2
 ### Hotfixes
 - **Send-LMWebhookMessage**: Fixed payload formatting when sending webhook messages to LM Logs:

--- a/Tests/ConvertTo-LMUptimeDevice.Tests.ps1
+++ b/Tests/ConvertTo-LMUptimeDevice.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'ConvertTo-LMUptimeDevice Testing' {
+Describe 'ConvertTo-LMUptimeDevice Testing' -Skip {
 
     BeforeAll {
         Import-Module $Module -Force

--- a/Tests/LMUptimeDevice.Tests.ps1
+++ b/Tests/LMUptimeDevice.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'Uptime Device Testing New/Get/Set/Remove' {
+Describe 'Uptime Device Testing New/Get/Set/Remove' -Skip {
 
     BeforeAll {
         Import-Module $Module -Force


### PR DESCRIPTION
## 7.7.5
### Cmdlet Changes
- **Get-LMDeviceData**: Fixed a bug that used the incorrect pagination logic when trying to enumerate additional pages of result data.
- **Get-LMDeviceData**: Added a new parameter *-Datapoints* which allows for filtering which datapoints are returned as part of the data export.

### New Cmdlets
- **Set-LMDeviceGroupDatasource**: This cmdlet modifies an existing device group datasource in LogicMonitor, allowing updates to monitoring state. This cmdlet provides control over the "Enable" checkbox (stopMonitoring) for a datasource applied to a device group. For alert settings use *Set-LMDeviceGroupDatasourceAlertSetting*.

### Important Notes
- **LM Uptime Removal**: Due to issues with the v3 api endpoints for LM Uptime, they are being temporarily removed from the module. As soon as they are officially supported in the LM Swagger guide they will be reintroduced along with the Website->Uptime conversion cmdlet. For previous versions of the module that still have access to these cmdlets it is recommended that you wait until the official swagger endpoints are released.